### PR TITLE
Updating cask price details in db and reporting.

### DIFF
--- a/R/beerfestdb.qmd
+++ b/R/beerfestdb.qmd
@@ -18,7 +18,7 @@ format:
     execute:
       warning: false
       cache: false
-date: '2025-09-30'
+date: '2025-10-08'
 ---
 
 ## Introduction
@@ -78,6 +78,14 @@ write.csv(cp, "full_dip_dump.csv", row.names = FALSE)
 Here we run the calculation of mean sales volumes and costs across container types and ABV ranges:
 
 ```{r calculation}
+# Function to fess up to all-NA values but to optionally gloss over partial-NA values (unreceived invoices)
+mysum <- function(x, ...) {
+  if (all(is.na(x))) {
+    return(NA)
+  } else {
+    return(sum(x, ...))
+  }
+}
 agg <- cp %>%
   group_by(
     company_name, product_name, cask_volume, size_name,
@@ -87,7 +95,7 @@ agg <- cp %>%
     pints_sold = sum(volume_sold) * 8, # Assumes volumes in gallons
     pints_lost = sum(volume_lost) * 8,
     pints_total = sum(cask_volume) * 8,
-    cost_total = sum(cask_price),
+    cost_total = mysum(cask_price, na.rm = TRUE), # na.rm=TRUE would ideally not be needed here (invoice issue)
     .groups = "drop"
   ) %>%
   mutate(
@@ -101,15 +109,16 @@ agg <- cp %>%
     pints_unsold = round(sum(pints_lost), 2),
     pints_total = round(sum(pints_total), 2),
     sales_total = round(sum(sales_total), 2),
-    cost_total = round(sum(cost_total), 2),
-    .groups = "drop"
+    cost_total = round(mysum(cost_total, na.rm = TRUE), 2)
   ) %>%
   mutate(
-    average_sale_price = round(sales_total / pints_sold, 2),
-    cost_per_pint = round(cost_total / pints_total, 2)
+    average_sale_price = ifelse(pints_sold > 0, round(sales_total / pints_sold, 2), NA),
+    cost_per_pint = ifelse(pints_total > 0, round(cost_total / pints_total, 2), NA)
   ) %>%
   arrange(size_name, is_sale_or_return, abv_class) %>%
-  select(-any_of(c("sales_total", "cost_total")))
+  select(-any_of(c("sales_total", "cost_total"))) %>%
+  mutate(across(c(average_sale_price, cost_per_pint), function(x) sprintf("%.2f", x))) %>%
+  ungroup()
 
 levels(agg$abv_class) <- sub(",", " - ", sub("\\[", "", sub("\\)", "%", levels(agg$abv_class))))
 ```

--- a/util/update_cask_details.pl
+++ b/util/update_cask_details.pl
@@ -44,12 +44,31 @@ has 'allow_stillage_move' => ( is       => 'ro',
                                default  => 0,
                                required => 1 );
 
+has 'require_stillage_loc' => ( is       => 'ro',
+                                isa      => 'Bool',
+                                default  => 1,
+                                required => 1 );
+
 has '_errors'   => ( is       => 'ro',
                      isa      => 'ArrayRef',
                      required => 1,
                      default  => sub { [] } );
 
 with 'BeerFestDB::MenuSelector';
+
+sub assign_cask_price {
+
+    my ( $self, $caskman, $price ) = @_;
+
+    if ( defined $price ) {
+        if ( ! looks_like_number( $price ) ) {
+            die("Error: This cask_price doesn't look like a number: $price\n");
+        }
+	$caskman->set_column('price', $price);
+    }
+
+    return;
+}
 
 sub assign_cellar_number {
 
@@ -99,9 +118,16 @@ sub update_caskman {
     # inadvertently screwing with another stillage's info.
     my $loc = $row->{ 'stillage_location' };
     if ( ! defined $loc ) {
-        die("Error: stillage_location not defined.");
+        die("Error: stillage_location not defined.") if $self->require_stillage_loc;
     }
-    $self->assign_stillage_location( $caskman, $loc );
+    else {
+	$self->assign_stillage_location( $caskman, $loc );
+    }
+
+    # Cask price.
+    if ( my $price = $row->{ 'cask_price' } ) {
+        $self->assign_cask_price($caskman, $price);
+    }
     
     # Cellar id ("internal_reference").
     if ( my $id = $row->{ 'cask_cellar_id' } ) {
@@ -186,7 +212,7 @@ sub load {
         unless ( first { $col eq $_ } qw(cask_festival_id cask_cellar_id
                                          stillage_location stillage_bay
                                          bay_position vented tapped ready
-                                         condemned) ) {
+                                         condemned cask_price) ) {
             die("Unrecognised column heading: $col\n");
         }
     }
@@ -252,11 +278,12 @@ package main;
 
 sub parse_args {
 
-    my ( $datafile, $allow_stillage_move, $want_help );
+    my ( $datafile, $allow_stillage_move, $force_load, $want_help );
 
     GetOptions(
 	"i|input=s"    => \$datafile,
 	"a|allow"      => \$allow_stillage_move,
+	"f|force"      => \$force_load,
         "h|help"       => \$want_help,
     );
 
@@ -279,15 +306,16 @@ sub parse_args {
 
     my $config = BeerFestDB::Web->config();
 
-    return( $config, $datafile, $allow_stillage_move );
+    return( $config, $datafile, $allow_stillage_move, $force_load );
 }
 
-my ( $config, $datafile, $allow_stillage_move ) = parse_args();
+my ( $config, $datafile, $allow_stillage_move, $force_load ) = parse_args();
 
 my $schema = BeerFestDB::ORM->connect( @{ $config->{'Model::DB'}{'connect_info'} } );
 
 my $updater = CaskUpdater->new( database            => $schema,
-                                allow_stillage_move => $allow_stillage_move );
+                                allow_stillage_move => $allow_stillage_move,
+                                require_stillage_loc => not $force_load );
 
 $updater->load( $datafile );
 
@@ -312,6 +340,11 @@ location, bay number and position once stillaging is complete.
 
 A flag indicating whether or not to allow casks to be automatically
 moved between stillages (default: no).
+
+=head2 -f
+
+A flag indicating that load should be attempted in the absence of the
+stillage location info. Not recommended for general use (default: no).
 
 =head2 -i
 


### PR DESCRIPTION
This PR enables the user to update cask prices (CaskManagement) using `update_cask_details.pl`. On occasion this may need to be done despite some of the casks not having been assigned to stillages, so we add the `--force` argument to the script to override the usual requirement that stillage location be supplied (use with care though). We're also improving reporting of cask prices to allow for the occasional unreceived invoice that would otherwise render all our cask price averages to be `NA`.