### PR TITLE
Minor bugfix and redis OIDC store config example

### DIFF
--- a/beerfestdb_web.yml
+++ b/beerfestdb_web.yml
@@ -77,6 +77,14 @@ Plugin::OpenIDConnect:
     key_id: 'my-key-1'
   clients:
     'dashboard':
-        client_secret: 'my-secret'
-        redirect_uris: 'http://localhost:8081/oauth2callback'
-
+       client_secret: 'my-secret'
+       redirect_uris: 'http://localhost:8501/oauth2callback'
+  # Optional Redis store configuration for OpenID Connect session management. Likely
+  # to be required for FastCGI deployments. If not specified, sessions will be stored
+  # in memory (not recommended for production use).
+  store_class: 'Catalyst::Plugin::OpenIDConnect::Utils::Store::Redis' 
+  store_args:
+    redis:
+      server: 'localhost:6379'
+      namespace: 'oidc:beerfestdb:'
+      code_ttl: 600

--- a/lib/BeerFestDB/Web/Controller/Root.pm
+++ b/lib/BeerFestDB/Web/Controller/Root.pm
@@ -120,7 +120,7 @@ sub login : Global {
 
         # OpenIDConnect case
         $c->log->debug("back parameter is set, will redirect to " . $back);
-        $c->stash->{url_success_target} = $c->flash->{url_success_target} = $c->uri_for($back);
+        $c->stash->{url_success_target} = $c->flash->{url_success_target} = '' . $c->uri_for($back);
 
     } else {
 


### PR DESCRIPTION
The bug fixed here manifested as having to click the login button twice when authenticating an OIDC client request. The fix is trivial. Also included is example configuration for the OIDC redis back-end store needed when running under FastCGI or similar.