### PR TITLE
Dashboard login timeout

### DIFF
--- a/tool_dashboard/CBF_tool_page.py
+++ b/tool_dashboard/CBF_tool_page.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 
 # Begin login and inactivity management ------------------------------------------------------
 # Configurable inactivity timeout (in minutes); set via .streamlit/secrets.toml [app] section.
-INACTIVITY_TIMEOUT_MINUTES = st.secrets.get("app", {}).get("inactivity_timeout_minutes", 60)
+timeout_mins = st.secrets.get("app", {}).get("inactivity_timeout_minutes", 60)
 
 st.set_page_config(page_title="BeerfestDB Tools", page_icon="favicon.ico")
 st.title("BeerfestDB Tools")
@@ -22,7 +22,7 @@ st.session_state.last_activity = datetime.now()
 
 @st.fragment(run_every=60)  # Check every 60 seconds
 def _inactivity_check():
-    timeout = timedelta(minutes=INACTIVITY_TIMEOUT_MINUTES)
+    timeout = timedelta(minutes=timeout_mins)
     if datetime.now() - st.session_state.last_activity > timeout:
         st.logout()
 

--- a/tool_dashboard/CBF_tool_page.py
+++ b/tool_dashboard/CBF_tool_page.py
@@ -1,18 +1,38 @@
 #%%
 import streamlit as st
+from datetime import datetime, timedelta
 
+# Begin login and inactivity management ------------------------------------------------------
+# Configurable inactivity timeout (in minutes); set via .streamlit/secrets.toml [app] section.
+INACTIVITY_TIMEOUT_MINUTES = st.secrets.get("app", {}).get("inactivity_timeout_minutes", 60)
+
+st.set_page_config(page_title="BeerfestDB Tools", page_icon="favicon.ico")
 st.title("BeerfestDB Tools")
-st.set_page_config(page_icon="favicon.ico")
 
 if not st.user.is_logged_in:
     if st.button("Log in with BeerfestDB account"):
         st.login()
     st.stop()
-else:
-    st.markdown(f"Welcome {st.user.name}!")
+
+# Update last_activity on every full (user-triggered) rerun.
+# The periodic fragment below only re-executes the fragment function,
+# leaving this line untouched, so last_activity correctly reflects
+# the most recent user interaction.
+st.session_state.last_activity = datetime.now()
+
+@st.fragment(run_every=60)  # Check every 60 seconds
+def _inactivity_check():
+    timeout = timedelta(minutes=INACTIVITY_TIMEOUT_MINUTES)
+    if datetime.now() - st.session_state.last_activity > timeout:
+        st.logout()
+
+_inactivity_check()
+
+st.markdown(f"Welcome {st.user.name}!")
 
 if st.button("Log out"):
     st.logout()
+# End login and inactivity management --------------------------------------------------------
 
 pages = {
     "Data Tables": [

--- a/tool_dashboard/README.md
+++ b/tool_dashboard/README.md
@@ -12,6 +12,8 @@ Also create a /path/to/.streamlit/ directory. This will hold the secrets.toml fi
 Create and activate a python virtual environment. Run the following to install dependencies:
 
 ``` bash
+python -m venv .venv
+. .venv/bin/activate
 pip install -r requirements.txt
 ```
 
@@ -19,6 +21,7 @@ Create a `.streamlit` subdirectory containing a file `secrets.toml` which looks 
 
 ```
 [connections.cbf]
+# Connection to the BeerFestDB MySQL/MariaDB database (read-only access only)
 dialect = "mysql"
 host = "127.0.0.1"
 port = 3306
@@ -27,12 +30,18 @@ username = "myusername"
 password = "mypassword"
 
 [auth]
+# Both secrets should be long, hard-to-guess strings. You will need to register the
+# redirect_uri, client_id and client_secret with the OpenID provider
 redirect_uri = "http://localhost:8501/oauth2callback"
 cookie_secret = "xxx"
 
 client_id = "dashboard"
 client_secret = "xxx"
 server_metadata_url = "http://localhost/.well-known/openid-configuration"
+
+[app]
+# Inactivity timeout in minutes before the user is automatically logged out.
+inactivity_timeout_minutes = 60
 ```
 
 Run the streamlit app:


### PR DESCRIPTION
This sort-of implements a login timeout to the dashboard, which is preferable to the current setup where the user is logged in indefinitely. There are ways in which this can fail, most notably if multiple different users access the dashboard in the same time period then the timer will be reset each time. Still, better than nothing.