### PR TITLE
72 additional admin cv pages

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -54,4 +54,5 @@ WriteMakefile(
             },
         },
     },
+    clean => { FILES => 't/pristine_testing.db t/testing.db' },
 );

--- a/db/create_tables.sql
+++ b/db/create_tables.sql
@@ -982,7 +982,7 @@ DROP TABLE IF EXISTS `product_characteristic`;
 CREATE TABLE `product_characteristic` (
   `product_id` int(6) NOT NULL,
   `product_characteristic_type_id` int(6) NOT NULL,
-  `value` int(11) unsigned DEFAULT NULL,
+  `value` varchar(32) NOT NULL,
   PRIMARY KEY (`product_id`),
   KEY `Rel_29` (`product_characteristic_type_id`),
   CONSTRAINT `product_characteristic_ibfk_1` FOREIGN KEY (`product_characteristic_type_id`) REFERENCES `product_characteristic_type` (`product_characteristic_type_id`) ON UPDATE NO ACTION,
@@ -1059,7 +1059,7 @@ CREATE TABLE `product_characteristic_type` (
   `product_characteristic_type_id` int(6) NOT NULL AUTO_INCREMENT,
   `product_category_id` int(6) NOT NULL,
   `description` varchar(50) NOT NULL,
-  PRIMARY KEY (`product_characteristic_type_id`,`product_category_id`),
+  PRIMARY KEY (`product_characteristic_type_id`),
   UNIQUE KEY `product_category_id` (`product_category_id`,`description`),
   CONSTRAINT `product_characteristic_type_ibfk_1` FOREIGN KEY (`product_category_id`) REFERENCES `product_category` (`product_category_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/db/migrations/20260505_fix_product_characteristic_type_pk_and_value_type.sql
+++ b/db/migrations/20260505_fix_product_characteristic_type_pk_and_value_type.sql
@@ -1,0 +1,40 @@
+-- Migration: Fix product_characteristic_type primary key; change product_characteristic.value type
+-- Date: 2026-05-05
+
+-- Change PRIMARY KEY on `product_characteristic_type` from composite
+-- (product_characteristic_type_id, product_category_id) to single-column
+-- (product_characteristic_type_id). The old composite PK caused new rows
+-- to be incorrectly matched by category when inserting via find_or_new.
+SET @pk_needs_fix := (
+  SELECT COUNT(*)
+  FROM information_schema.KEY_COLUMN_USAGE
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME   = 'product_characteristic_type'
+    AND CONSTRAINT_NAME = 'PRIMARY'
+    AND COLUMN_NAME  = 'product_category_id'
+);
+SET @sql := IF(@pk_needs_fix > 0,
+  'ALTER TABLE `product_characteristic_type` DROP PRIMARY KEY, ADD PRIMARY KEY (`product_characteristic_type_id`);',
+  'SELECT "product_characteristic_type primary key already updated";'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- Change `product_characteristic`.`value` from int(11) unsigned NULL to varchar(32) NOT NULL.
+-- First convert any NULL values to empty string so the NOT NULL constraint can be applied.
+UPDATE `product_characteristic` SET `value` = '' WHERE `value` IS NULL;
+
+SET @col_needs_fix := (
+  SELECT COUNT(*)
+  FROM information_schema.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME   = 'product_characteristic'
+    AND COLUMN_NAME  = 'value'
+    AND DATA_TYPE    = 'int'
+);
+SET @sql := IF(@col_needs_fix > 0,
+  'ALTER TABLE `product_characteristic` MODIFY COLUMN `value` VARCHAR(32) NOT NULL;',
+  'SELECT "product_characteristic.value already updated";'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- End of migration

--- a/lib/BeerFestDB/ORM/ProductCharacteristic.pm
+++ b/lib/BeerFestDB/ORM/ProductCharacteristic.pm
@@ -37,9 +37,9 @@ __PACKAGE__->table("product_characteristic");
 
 =head2 value
 
-  data_type: 'integer'
-  extra: {unsigned => 1}
-  is_nullable: 1
+  data_type: 'varchar'
+  is_nullable: 0
+  size: 32
 
 =cut
 
@@ -49,7 +49,7 @@ __PACKAGE__->add_columns(
   "product_characteristic_type_id",
   { data_type => "integer", is_foreign_key => 1, is_nullable => 0 },
   "value",
-  { data_type => "integer", extra => { unsigned => 1 }, is_nullable => 1 },
+  { data_type => "varchar", is_nullable => 0, size => 32 },
 );
 
 =head1 PRIMARY KEY

--- a/lib/BeerFestDB/ORM/ProductCharacteristicType.pm
+++ b/lib/BeerFestDB/ORM/ProductCharacteristicType.pm
@@ -64,7 +64,7 @@ __PACKAGE__->add_columns(
 
 =cut
 
-__PACKAGE__->set_primary_key("product_characteristic_type_id", "product_category_id");
+__PACKAGE__->set_primary_key("product_characteristic_type_id");
 
 =head1 UNIQUE CONSTRAINTS
 

--- a/lib/BeerFestDB/Web.pm
+++ b/lib/BeerFestDB/Web.pm
@@ -139,7 +139,8 @@ foreach my $path ( qw(productstyle) ) {
 }
 foreach my $path ( qw(bayposition companyregion contacttype containermeasure
                       containersize country currency dispensemethod
-                      productallergentype productcategory productstyle
+                      productallergentype productcharacteristictype
+                      productcategory productstyle
                       salevolume telephonetype) ) {
     __PACKAGE__->allow_access_if( "/$path/list", [ qw( user ) ] );
     __PACKAGE__->allow_access_if( '/' . $path, [ qw( admin ) ] );

--- a/lib/BeerFestDB/Web/Controller/BayPosition.pm
+++ b/lib/BeerFestDB/Web/Controller/BayPosition.pm
@@ -23,7 +23,7 @@ package BeerFestDB::Web::Controller::BayPosition;
 use Moose;
 use namespace::autoclean;
 
-BEGIN {extends 'BeerFestDB::Web::Controller'; }
+BEGIN {extends 'BeerFestDB::Web::GenericGrid'; }
 
 =head1 NAME
 
@@ -45,19 +45,42 @@ sub BUILD {
         bay_position_id  => 'bay_position_id',
         description      => 'description',
     });
+
+    $self->model_name('DB::BayPosition');
 }
 
-=head2 list
+=head2 load_form
 
 =cut
 
-sub list : Local {
+sub load_form : Local {
 
     my ( $self, $c ) = @_;
 
-    my $rs = $c->model( 'DB::BayPosition' );
+    my $rs = $c->model( $self->model_name() );
 
-    $self->generate_json_and_detach( $c, $rs );
+    $self->form_json_and_detach( $c, $rs, 'bay_position_id' );
+}
+
+=head2 view
+
+=cut
+
+sub view : Local {
+
+    my ( $self, $c, $id ) = @_;
+
+    my $object = $c->model( $self->model_name() )->find($id);
+
+    unless ( $object ) {
+        $c->flash->{error} = "Error: BayPosition not found.";
+        $c->res->redirect( $c->uri_for('/default') );
+        $c->detach();        
+    }
+
+    $c->stash->{object} = $object;
+
+    return;
 }
 
 =head1 COPYRIGHT AND LICENSE

--- a/lib/BeerFestDB/Web/Controller/ContainerMeasure.pm
+++ b/lib/BeerFestDB/Web/Controller/ContainerMeasure.pm
@@ -50,6 +50,40 @@ sub BUILD {
     $self->model_name('DB::ContainerMeasure');
 }
 
+=head2 load_form
+
+=cut
+
+sub load_form : Local {
+
+    my ( $self, $c ) = @_;
+
+    my $rs = $c->model( $self->model_name() );
+
+    $self->form_json_and_detach( $c, $rs, 'container_measure_id' );
+}
+
+=head2 view
+
+=cut
+
+sub view : Local {
+
+    my ( $self, $c, $id ) = @_;
+
+    my $object = $c->model( $self->model_name() )->find($id);
+
+    unless ( $object ) {
+        $c->flash->{error} = "Error: ContainerMeasure not found.";
+        $c->res->redirect( $c->uri_for('/default') );
+        $c->detach();        
+    }
+
+    $c->stash->{object} = $object;
+
+    return;
+}
+
 =head1 COPYRIGHT AND LICENSE
 
 Copyright (C) 2017 by Tim F. Rayner

--- a/lib/BeerFestDB/Web/Controller/Country.pm
+++ b/lib/BeerFestDB/Web/Controller/Country.pm
@@ -2,7 +2,7 @@
 # This file is part of BeerFestDB, a beer festival product management
 # system.
 # 
-# Copyright (C) 2010 Tim F. Rayner
+# Copyright (C) 2010-2026 by Tim F. Rayner
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -23,7 +23,7 @@ package BeerFestDB::Web::Controller::Country;
 use Moose;
 use namespace::autoclean;
 
-BEGIN {extends 'BeerFestDB::Web::Controller'; }
+BEGIN {extends 'BeerFestDB::Web::GenericGrid'; }
 
 =head1 NAME
 
@@ -48,24 +48,47 @@ sub BUILD {
         country_code_num3 => 'country_code_num3',
         country_name      => 'country_name',
     });
+
+    $self->model_name('DB::Country');
 }
 
-=head2 list
+=head2 load_form
 
 =cut
 
-sub list : Local {
+sub load_form : Local {
 
     my ( $self, $c ) = @_;
 
-    my $rs = $c->model( 'DB::Country' );
+    my $rs = $c->model( $self->model_name() );
 
-    $self->generate_json_and_detach( $c, $rs );
+    $self->form_json_and_detach( $c, $rs, 'country_id' );
+}
+
+=head2 view
+
+=cut
+
+sub view : Local {
+
+    my ( $self, $c, $id ) = @_;
+
+    my $object = $c->model( $self->model_name() )->find($id);
+
+    unless ( $object ) {
+        $c->flash->{error} = "Error: Country not found.";
+        $c->res->redirect( $c->uri_for('/default') );
+        $c->detach();        
+    }
+
+    $c->stash->{object} = $object;
+
+    return;
 }
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2010 by Tim F. Rayner
+Copyright (C) 2010-2026 by Tim F. Rayner
 
 This library is released under version 3 of the GNU General Public
 License (GPL).

--- a/lib/BeerFestDB/Web/Controller/Currency.pm
+++ b/lib/BeerFestDB/Web/Controller/Currency.pm
@@ -2,7 +2,7 @@
 # This file is part of BeerFestDB, a beer festival product management
 # system.
 # 
-# Copyright (C) 2010 Tim F. Rayner
+# Copyright (C) 2010-2026 by Tim F. Rayner
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -23,7 +23,7 @@ package BeerFestDB::Web::Controller::Currency;
 use Moose;
 use namespace::autoclean;
 
-BEGIN {extends 'BeerFestDB::Web::Controller'; }
+BEGIN {extends 'BeerFestDB::Web::GenericGrid'; }
 
 =head1 NAME
 
@@ -49,24 +49,47 @@ sub BUILD {
         exponent        => 'exponent',
         currency_symbol => 'currency_symbol',
     });
+
+    $self->model_name('DB::Currency');
 }
 
-=head2 list
+=head2 load_form
 
 =cut
 
-sub list : Local {
+sub load_form : Local {
 
     my ( $self, $c ) = @_;
 
-    my $rs = $c->model( 'DB::Currency' );
+    my $rs = $c->model( $self->model_name() );
 
-    $self->generate_json_and_detach( $c, $rs );
+    $self->form_json_and_detach( $c, $rs, 'currency_id' );
+}
+
+=head2 view
+
+=cut
+
+sub view : Local {
+
+    my ( $self, $c, $id ) = @_;
+
+    my $object = $c->model( $self->model_name() )->find($id);
+
+    unless ( $object ) {
+        $c->flash->{error} = "Error: Currency not found.";
+        $c->res->redirect( $c->uri_for('/default') );
+        $c->detach();        
+    }
+
+    $c->stash->{object} = $object;
+
+    return;
 }
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2010 by Tim F. Rayner
+Copyright (C) 2010-2026 by Tim F. Rayner
 
 This library is released under version 3 of the GNU General Public
 License (GPL).

--- a/lib/BeerFestDB/Web/Controller/ProductCharacteristicType.pm
+++ b/lib/BeerFestDB/Web/Controller/ProductCharacteristicType.pm
@@ -112,6 +112,25 @@ sub list_by_category : Local {
     $self->generate_json_and_detach( $c, $rs );
 }
 
+=head2 grid
+
+=cut
+
+sub grid : Local {
+
+    my ( $self, $c, $category_id ) = @_;
+
+    if ( defined $category_id ) {
+        my $category = $c->model( 'DB::ProductCategory' )->find($category_id);
+        unless ( $category ) {
+            $c->flash->{error} = "Error: Product Category not found.";
+            $c->res->redirect( $c->uri_for('/default') );
+            $c->detach();
+        }
+        $c->stash->{category} = $category;
+    }
+}
+
 =head1 COPYRIGHT AND LICENSE
 
 Copyright (C) 2017-2026 by Tim F. Rayner

--- a/lib/BeerFestDB/Web/Controller/ProductCharacteristicType.pm
+++ b/lib/BeerFestDB/Web/Controller/ProductCharacteristicType.pm
@@ -2,7 +2,7 @@
 # This file is part of BeerFestDB, a beer festival product management
 # system.
 # 
-# Copyright (C) 2010 Tim F. Rayner
+# Copyright (C) 2017 Tim F. Rayner
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,15 +19,15 @@
 #
 # $Id$
 
-package BeerFestDB::Web::Controller::ProductCategory;
+package BeerFestDB::Web::Controller::ProductCharacteristicType;
 use Moose;
 use namespace::autoclean;
 
-BEGIN {extends 'BeerFestDB::Web::GenericGrid'; }
+BEGIN { extends 'BeerFestDB::Web::GenericGrid'; }
 
 =head1 NAME
 
-BeerFestDB::Web::Controller::ProductCategory - Catalyst Controller
+BeerFestDB::Web::Controller::ProductCharacteristicType - Catalyst Controller
 
 =head1 DESCRIPTION
 
@@ -42,11 +42,12 @@ sub BUILD {
     my ( $self, $params ) = @_;
 
     $self->model_view_map({
-        product_category_id   => 'product_category_id',
-        description           => 'description',
+        product_characteristic_type_id => 'product_characteristic_type_id',
+        product_category_id            => 'product_category_id',
+        description                    => 'description',
     });
 
-    $self->model_name('DB::ProductCategory');
+    $self->model_name('DB::ProductCharacteristicType');
 }
 
 =head2 load_form
@@ -59,7 +60,7 @@ sub load_form : Local {
 
     my $rs = $c->model( $self->model_name() );
 
-    $self->form_json_and_detach( $c, $rs, 'product_category_id' );
+    $self->form_json_and_detach( $c, $rs, 'product_characteristic_type_id' );
 }
 
 =head2 view
@@ -73,7 +74,7 @@ sub view : Local {
     my $object = $c->model( $self->model_name() )->find($id);
 
     unless ( $object ) {
-        $c->flash->{error} = "Error: ProductCategory not found.";
+        $c->flash->{error} = "Error: ProductCharacteristicType not found.";
         $c->res->redirect( $c->uri_for('/default') );
         $c->detach();        
     }
@@ -83,9 +84,37 @@ sub view : Local {
     return;
 }
 
+=head2 list
+
+=cut
+
+sub list : Local {
+
+    my ( $self, $c ) = @_;
+
+    if ( my $category_id = $c->req()->params()->{ product_category_id } ) {
+        $c->res->redirect( $c->uri_for('list_by_category', $category_id) );
+    } else {
+        $self->SUPER::list($c);
+    }
+}
+
+=head2 list_by_category
+
+=cut
+
+sub list_by_category : Local {
+
+    my ( $self, $c, $id ) = @_;
+
+    my $rs = $c->model( $self->model_name() )->search({ product_category_id => $id });
+
+    $self->generate_json_and_detach( $c, $rs );
+}
+
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2010 by Tim F. Rayner
+Copyright (C) 2017-2026 by Tim F. Rayner
 
 This library is released under version 3 of the GNU General Public
 License (GPL).

--- a/root/lib/site/html
+++ b/root/lib/site/html
@@ -70,6 +70,10 @@
    var url_container_measure_submit  = '[% c.uri_for( "/containermeasure/submit" ) %]';
    var url_company_delete       = '[% c.uri_for( "/company/delete" ) %]';
    var url_company_submit       = '[% c.uri_for( "/company/submit" ) %]';
+   var url_country_delete       = '[% c.uri_for( "/country/delete" ) %]';
+   var url_country_submit       = '[% c.uri_for( "/country/submit" ) %]';
+   var url_currency_delete      = '[% c.uri_for( "/currency/delete" ) %]';
+   var url_currency_submit      = '[% c.uri_for( "/currency/submit" ) %]';
    var url_company_region_delete = '[% c.uri_for( "/companyregion/delete" ) %]';
    var url_company_region_submit = '[% c.uri_for( "/companyregion/submit" ) %]';
    var url_dispense_method_delete = '[% c.uri_for( "/dispensemethod/delete" ) %]';

--- a/root/lib/site/html
+++ b/root/lib/site/html
@@ -44,6 +44,7 @@
    var url_festival_list        = '[% c.uri_for( "/festival/list" ) %]';
    var url_product_list         = '[% c.uri_for( "/product/list" ) %]';
    var url_product_allergen_list = '[% c.uri_for( "/productallergentype/list" ) %]';
+   var url_product_characteristic_type_list = '[% c.uri_for( "/productcharacteristictype/list" ) %]';
    var url_product_style_list   = '[% c.uri_for( "/productstyle/list" ) %]';
    var url_sale_volume_list     = '[% c.uri_for( "/salevolume/list" ) %]';
    var url_bay_position_list    = '[% c.uri_for( "/bayposition/list" ) %]';
@@ -87,6 +88,10 @@
    var url_product_delete       = '[% c.uri_for( "/product/delete" ) %]';
    var url_product_allergen_delete = '[% c.uri_for( "/productallergentype/delete" ) %]';
    var url_product_allergen_submit = '[% c.uri_for( "/productallergentype/submit" ) %]';
+   var url_product_category_delete = '[% c.uri_for( "/productcategory/delete" ) %]';
+   var url_product_category_submit = '[% c.uri_for( "/productcategory/submit" ) %]';
+   var url_product_characteristic_type_delete = '[% c.uri_for( "/productcharacteristictype/delete" ) %]';
+   var url_product_characteristic_type_submit = '[% c.uri_for( "/productcharacteristictype/submit" ) %]';
    var url_productorder_delete  = '[% c.uri_for( "/productorder/delete" ) %]';
    var url_productorder_submit  = '[% c.uri_for( "/productorder/submit" ) %]';
    var url_productstyle_submit  = '[% c.uri_for( "/productstyle/submit" ) %]';

--- a/root/lib/site/html
+++ b/root/lib/site/html
@@ -53,6 +53,8 @@
    var url_role_list            = '[% c.uri_for( "/role/list" ) %]';
    var url_user_list            = '[% c.uri_for( "/user/list" ) %]';
 
+   var url_bay_position_delete  = '[% c.uri_for( "/bayposition/delete" ) %]';
+   var url_bay_position_submit  = '[% c.uri_for( "/bayposition/submit" ) %]';
    var url_cask_delete          = '[% c.uri_for( "/cask/delete" ) %]';
    var url_cask_submit          = '[% c.uri_for( "/cask/submit" ) %]';
    var url_cask_size_delete     = '[% c.uri_for( "/containersize/delete" ) %]';

--- a/root/lib/site/html
+++ b/root/lib/site/html
@@ -65,6 +65,8 @@
    var url_category_delete      = '[% c.uri_for( "/productcategory/delete" ) %]';
    var url_contact_delete       = '[% c.uri_for( "/contact/delete" ) %]';
    var url_contact_submit       = '[% c.uri_for( "/contact/submit" ) %]';
+   var url_container_measure_delete  = '[% c.uri_for( "/containermeasure/delete" ) %]';
+   var url_container_measure_submit  = '[% c.uri_for( "/containermeasure/submit" ) %]';
    var url_company_delete       = '[% c.uri_for( "/company/delete" ) %]';
    var url_company_submit       = '[% c.uri_for( "/company/submit" ) %]';
    var url_company_region_delete = '[% c.uri_for( "/companyregion/delete" ) %]';

--- a/root/src/bayposition/grid.tt2
+++ b/root/src/bayposition/grid.tt2
@@ -1,0 +1,5 @@
+[% META title = 'Bay Position listing' %]
+
+[% js_link( src = '/static/js/grids/bay_positions.js' ) %]
+
+<div id="datagrid"></div>

--- a/root/src/bayposition/view.tt2
+++ b/root/src/bayposition/view.tt2
@@ -1,0 +1,12 @@
+[% META title = 'Bay Position Details' %]
+
+<script type="text/javascript">
+   var url_bay_position_load_form = '[% c.uri_for( "/bayposition/load_form" ) %]';
+   var url_bay_position_grid = '[% c.uri_for( "/bayposition/grid" ) %]';
+   
+   var bay_position_id = '[% object.id %]';
+</script>
+
+[% js_link( src = '/static/js/grids/bay_position_view.js' ) %]
+
+<div id="datagrid"></div>

--- a/root/src/companyregion/view.tt2
+++ b/root/src/companyregion/view.tt2
@@ -2,6 +2,7 @@
 
 <script type="text/javascript">
    var url_company_region_load_form = '[% c.uri_for( "/companyregion/load_form" ) %]';
+   var url_company_region_grid = '[% c.uri_for( "/companyregion/grid" ) %]';
    
    var company_region_id = '[% object.id %]';
 </script>

--- a/root/src/containermeasure/grid.tt2
+++ b/root/src/containermeasure/grid.tt2
@@ -1,0 +1,5 @@
+[% META title = 'Container Measure listing' %]
+
+[% js_link( src = '/static/js/grids/container_measures.js' ) %]
+
+<div id="datagrid"></div>

--- a/root/src/containermeasure/view.tt2
+++ b/root/src/containermeasure/view.tt2
@@ -1,0 +1,12 @@
+[% META title = 'Container Measure Details' %]
+
+<script type="text/javascript">
+   var url_container_measure_load_form = '[% c.uri_for( "/containermeasure/load_form" ) %]';
+   var url_container_measure_grid = '[% c.uri_for( "/containermeasure/grid" ) %]';
+   
+   var container_measure_id = '[% object.id %]';
+</script>
+
+[% js_link( src = '/static/js/grids/container_measure_view.js' ) %]
+
+<div id="datagrid"></div>

--- a/root/src/containersize/view.tt2
+++ b/root/src/containersize/view.tt2
@@ -2,6 +2,7 @@
 
 <script type="text/javascript">
    var url_container_size_load_form = '[% c.uri_for( "/containersize/load_form" ) %]';
+   var url_container_size_grid = '[% c.uri_for( "/containersize/grid" ) %]';
    
    var container_size_id = '[% object.id %]';
 </script>

--- a/root/src/country/grid.tt2
+++ b/root/src/country/grid.tt2
@@ -1,0 +1,5 @@
+[% META title = 'Country listing' %]
+
+[% js_link( src = '/static/js/grids/countries.js' ) %]
+
+<div id="datagrid"></div>

--- a/root/src/country/view.tt2
+++ b/root/src/country/view.tt2
@@ -1,0 +1,12 @@
+[% META title = 'Country Details' %]
+
+<script type="text/javascript">
+   var url_country_load_form = '[% c.uri_for( "/country/load_form" ) %]';
+   var url_country_grid = '[% c.uri_for( "/country/grid" ) %]';
+   
+   var country_id = '[% object.id %]';
+</script>
+
+[% js_link( src = '/static/js/grids/country_view.js' ) %]
+
+<div id="datagrid"></div>

--- a/root/src/currency/grid.tt2
+++ b/root/src/currency/grid.tt2
@@ -1,0 +1,5 @@
+[% META title = 'Currency listing' %]
+
+[% js_link( src = '/static/js/grids/currencies.js' ) %]
+
+<div id="datagrid"></div>

--- a/root/src/currency/view.tt2
+++ b/root/src/currency/view.tt2
@@ -1,0 +1,12 @@
+[% META title = 'Currency Details' %]
+
+<script type="text/javascript">
+   var url_currency_load_form = '[% c.uri_for( "/currency/load_form" ) %]';
+   var url_currency_grid = '[% c.uri_for( "/currency/grid" ) %]';
+   
+   var currency_id = '[% object.id %]';
+</script>
+
+[% js_link( src = '/static/js/grids/currency_view.js' ) %]
+
+<div id="datagrid"></div>

--- a/root/src/dispensemethod/view.tt2
+++ b/root/src/dispensemethod/view.tt2
@@ -2,6 +2,7 @@
 
 <script type="text/javascript">
    var url_dispense_method_load_form = '[% c.uri_for( "/dispensemethod/load_form" ) %]';
+   var url_dispense_method_grid = '[% c.uri_for( "/dispensemethod/grid" ) %]';
    
    var dispense_method_id = '[% object.id %]';
 </script>

--- a/root/src/index.tt2
+++ b/root/src/index.tt2
@@ -93,14 +93,14 @@
 
 <div id="bfdb-panels">
 
-  <div class="bfdb-panel" id="main-menu">
+  <div class="bfdb-panel" id="bfdb-main-menu">
     <h2>Festival &amp; Products</h2>
     <p>Day-to-day management of festivals, suppliers and products.</p>
     <a class="bfdb-card" href="[% c.uri_for('/festival/grid') %]">Festival Records</a>
     <a class="bfdb-card" href="[% c.uri_for('/company/grid') %]">Supplier and Product Listings</a>
   </div>
 
-  <div class="bfdb-panel" id="admin-menu">
+  <div class="bfdb-panel" id="bfdb-admin-menu">
     <h2>Database Administration</h2>
     <p>Configuration pages restricted to admin-level users.</p>
 
@@ -129,6 +129,4 @@
 </div>
 
 </div>
-
-[% js_link( src = '/static/js/grids/main.js' ) %]
 

--- a/root/src/index.tt2
+++ b/root/src/index.tt2
@@ -117,12 +117,14 @@
 
     <div class="bfdb-subgroup">
       <h3>Logistics</h3>
-      <a class="bfdb-card" href="[% c.uri_for('/dispensemethod/grid') %]">Dispense methods</a>
       <a class="bfdb-card" href="[% c.uri_for('/containersize/grid') %]">Cask and other container sizes</a>
       <a class="bfdb-card" href="[% c.uri_for('/salevolume/grid') %]">Sale volume sizes</a>
-      <a class="bfdb-card" href="[% c.uri_for('/companyregion/grid') %]">Company geographic regions</a>
-      <a class="bfdb-card" href="[% c.uri_for('/bayposition/grid') %]">Bay positions</a>
       <a class="bfdb-card" href="[% c.uri_for('/containermeasure/grid') %]">Container measures</a>
+      <a class="bfdb-card" href="[% c.uri_for('/dispensemethod/grid') %]">Dispense methods</a>
+      <a class="bfdb-card" href="[% c.uri_for('/bayposition/grid') %]">Bay positions</a>
+      <a class="bfdb-card" href="[% c.uri_for('/companyregion/grid') %]">Company geographic regions</a>
+      <a class="bfdb-card" href="[% c.uri_for('/country/grid') %]">Countries</a>
+      <a class="bfdb-card" href="[% c.uri_for('/currency/grid') %]">Currencies</a>
     </div>
   </div>
 

--- a/root/src/index.tt2
+++ b/root/src/index.tt2
@@ -1,41 +1,130 @@
 [% META title = "Welcome to BeerFestDB" %]
 
+<style type="text/css">
+  #bfdb-hero {
+    background: linear-gradient(135deg, #b35c00 0%, #e8890a 60%, #f5b942 100%);
+    color: #fff;
+    text-align: center;
+    padding: 2.5em 1em 2em;
+    margin-bottom: 0;
+  }
+  #bfdb-hero h1 {
+    margin: 0 0 0.4em;
+    font-size: 2em;
+    letter-spacing: 0.03em;
+    text-shadow: 0 1px 3px rgba(0,0,0,0.35);
+  }
+  #bfdb-hero p {
+    margin: 0;
+    font-size: 1em;
+    opacity: 0.92;
+  }
+  #bfdb-panels {
+    display: flex;
+    gap: 2em;
+    padding: 2em;
+    max-width: 960px;
+    margin: 0 auto;
+    box-sizing: border-box;
+  }
+  .bfdb-panel {
+    flex: 1;
+    background: #fff;
+    border-radius: 6px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.13);
+    padding: 1.5em;
+    box-sizing: border-box;
+  }
+  .bfdb-panel h2 {
+    margin: 0 0 0.8em;
+    font-size: 1.1em;
+    padding-left: 0.6em;
+    border-left: 4px solid #e8890a;
+    color: #333;
+  }
+  .bfdb-panel > p {
+    font-size: 0.9em;
+    color: #555;
+    margin: 0 0 1em;
+  }
+  .bfdb-card {
+    display: block;
+    padding: 0.55em 0.9em;
+    margin: 0.35em 0;
+    border-radius: 4px;
+    background: #f5f5f5;
+    text-decoration: none;
+    color: #333;
+    font-size: 0.95em;
+    transition: background 0.15s, color 0.15s;
+  }
+  .bfdb-card:hover {
+    background: #ffe0a0;
+    color: #000;
+  }
+  .bfdb-subgroup {
+    margin-top: 1.1em;
+  }
+  .bfdb-subgroup h3 {
+    margin: 0 0 0.4em;
+    font-size: 0.72em;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #999;
+  }
+  @media (max-width: 640px) {
+    #bfdb-panels {
+      flex-direction: column;
+      padding: 1em;
+    }
+  }
+</style>
+
 <div id="html-content">
 
-<div class="menu" id="main-menu">
-
-  <div class="heading"><h1>Welcome to BeerFestDB</h1></div>
-
-    [% IF message %] 
-      <p class="textblock"><span class="message">[% message | html %]</span></p> 
-    [% END %] 
-
-  <p class="textblock">This is the main entry page for the BeerFestDB product management web site. Please use the links below to navigate:</p>
-
-  <ul class="linkslist"> 
-    <li><a href="[% c.uri_for('/festival/grid') %]">Festival Records</a></li> 
-    <li><a href="[% c.uri_for('/company/grid') %]">Supplier and Product Listings</a></li> 
-  </ul>
-
+<div id="bfdb-hero">
+  <h1>Welcome to BeerFestDB</h1>
+  [% IF message %]
+    <p><span class="message">[% message | html %]</span></p>
+  [% ELSE %]
+    <p>Beer festival product management &mdash; use the panels below to navigate.</p>
+  [% END %]
 </div>
 
-<div class="menu" id="admin-menu">
+<div id="bfdb-panels">
 
-  <div class="heading"><h1>BeerfestDB Database Administration</h1></div>
+  <div class="bfdb-panel" id="main-menu">
+    <h2>Festival &amp; Products</h2>
+    <p>Day-to-day management of festivals, suppliers and products.</p>
+    <a class="bfdb-card" href="[% c.uri_for('/festival/grid') %]">Festival Records</a>
+    <a class="bfdb-card" href="[% c.uri_for('/company/grid') %]">Supplier and Product Listings</a>
+  </div>
 
-  <p class="textblock">This area is used to make changes to the way the database is organised. Access to the following pages is restricted to admin-level users:</p>
+  <div class="bfdb-panel" id="admin-menu">
+    <h2>Database Administration</h2>
+    <p>Configuration pages restricted to admin-level users.</p>
 
-  <ul class="linkslist">
-    <li><a href="[% c.uri_for('/user/grid') %]">Database users and roles</a></li>
-    <li><a href="[% c.uri_for('/productcategory/grid') %]">Product categories, styles and characteristics</a></li>
-    <li><a href="[% c.uri_for('/productallergentype/grid') %]">Allergen types</a></li>
-    <li><a href="[% c.uri_for('/dispensemethod/grid') %]">Dispense methods</a></li>
-    <li><a href="[% c.uri_for('/containersize/grid') %]">Cask and other container sizes</a></li>
-    <li><a href="[% c.uri_for('/salevolume/grid') %]">Sale volume sizes</a></li>
-    <li><a href="[% c.uri_for('/companyregion/grid') %]">Company geographic regions</a></li>
-    <li><a href="[% c.uri_for('/bayposition/grid') %]">Bay positions</a></li>
-    <li><a href="[% c.uri_for('/containermeasure/grid') %]">Container measures</a></li>
-  </ul>
+    <div class="bfdb-subgroup">
+      <h3>Users</h3>
+      <a class="bfdb-card" href="[% c.uri_for('/user/grid') %]">Database users and roles</a>
+    </div>
+
+    <div class="bfdb-subgroup">
+      <h3>Products</h3>
+      <a class="bfdb-card" href="[% c.uri_for('/productcategory/grid') %]">Product categories, styles and characteristics</a>
+      <a class="bfdb-card" href="[% c.uri_for('/productallergentype/grid') %]">Allergen types</a>
+    </div>
+
+    <div class="bfdb-subgroup">
+      <h3>Logistics</h3>
+      <a class="bfdb-card" href="[% c.uri_for('/dispensemethod/grid') %]">Dispense methods</a>
+      <a class="bfdb-card" href="[% c.uri_for('/containersize/grid') %]">Cask and other container sizes</a>
+      <a class="bfdb-card" href="[% c.uri_for('/salevolume/grid') %]">Sale volume sizes</a>
+      <a class="bfdb-card" href="[% c.uri_for('/companyregion/grid') %]">Company geographic regions</a>
+      <a class="bfdb-card" href="[% c.uri_for('/bayposition/grid') %]">Bay positions</a>
+      <a class="bfdb-card" href="[% c.uri_for('/containermeasure/grid') %]">Container measures</a>
+    </div>
+  </div>
 
 </div>
 

--- a/root/src/index.tt2
+++ b/root/src/index.tt2
@@ -34,6 +34,7 @@
     <li><a href="[% c.uri_for('/salevolume/grid') %]">Sale volume sizes</a></li>
     <li><a href="[% c.uri_for('/companyregion/grid') %]">Company geographic regions</a></li>
     <li><a href="[% c.uri_for('/bayposition/grid') %]">Bay positions</a></li>
+    <li><a href="[% c.uri_for('/containermeasure/grid') %]">Container measures</a></li>
   </ul>
 
 </div>

--- a/root/src/index.tt2
+++ b/root/src/index.tt2
@@ -33,6 +33,7 @@
     <li><a href="[% c.uri_for('/containersize/grid') %]">Cask and other container sizes</a></li>
     <li><a href="[% c.uri_for('/salevolume/grid') %]">Sale volume sizes</a></li>
     <li><a href="[% c.uri_for('/companyregion/grid') %]">Company geographic regions</a></li>
+    <li><a href="[% c.uri_for('/bayposition/grid') %]">Bay positions</a></li>
   </ul>
 
 </div>

--- a/root/src/index.tt2
+++ b/root/src/index.tt2
@@ -27,7 +27,7 @@
 
   <ul class="linkslist">
     <li><a href="[% c.uri_for('/user/grid') %]">Database users and roles</a></li>
-    <li><a href="[% c.uri_for('/productcategory/grid') %]">Product categorisation</a></li>
+    <li><a href="[% c.uri_for('/productcategory/grid') %]">Product categories, styles and characteristics</a></li>
     <li><a href="[% c.uri_for('/productallergentype/grid') %]">Allergen types</a></li>
     <li><a href="[% c.uri_for('/dispensemethod/grid') %]">Dispense methods</a></li>
     <li><a href="[% c.uri_for('/containersize/grid') %]">Cask and other container sizes</a></li>

--- a/root/src/productallergentype/view.tt2
+++ b/root/src/productallergentype/view.tt2
@@ -2,6 +2,7 @@
 
 <script type="text/javascript">
    var url_product_allergen_type_load_form = '[% c.uri_for( "/productallergentype/load_form" ) %]';
+   var url_product_allergen_type_grid = '[% c.uri_for( "/productallergentype/grid" ) %]';
    
    var product_allergen_type_id = '[% object.id %]';
 </script>

--- a/root/src/productcategory/view.tt2
+++ b/root/src/productcategory/view.tt2
@@ -1,0 +1,15 @@
+[% META title = 'Product Category Details' %]
+
+<script type="text/javascript">
+   var url_product_category_load_form = '[% c.uri_for( "/productcategory/load_form" ) %]';
+   var url_product_category_grid = '[% c.uri_for( "/productcategory/grid" ) %]';
+   
+   var url_product_style_list = '[% c.uri_for( "/productstyle/list_by_category", object.id ) %]';
+   var url_product_characteristic_type_list = '[% c.uri_for( "/productcharacteristictype/list_by_category", object.id ) %]';
+   
+   var product_category_id = '[% object.id %]';
+</script>
+
+[% js_link( src = '/static/js/grids/product_category_view.js' ) %]
+
+<div id="datagrid"></div>

--- a/root/src/productcharacteristictype/grid.tt2
+++ b/root/src/productcharacteristictype/grid.tt2
@@ -1,7 +1,10 @@
 [% META title = 'Product Characteristic Type listing' %]
 
 <script type="text/javascript">
+   var url_object_list    = '[% c.uri_for( "/productcharacteristictype/list_by_category/$category.id" ) %]';
    var url_category_view  = '[% c.uri_for( "/productcategory/grid" ) %]';
+   var categoryname       = '[% category.description | xml %]';
+   var category_id        = '[% category.id | xml %]';
 </script>
 
 [% js_link( src = '/static/js/grids/product_characteristic_types.js' ) %]

--- a/root/src/productcharacteristictype/grid.tt2
+++ b/root/src/productcharacteristictype/grid.tt2
@@ -1,0 +1,9 @@
+[% META title = 'Product Characteristic Type listing' %]
+
+<script type="text/javascript">
+   var url_category_view  = '[% c.uri_for( "/productcategory/grid" ) %]';
+</script>
+
+[% js_link( src = '/static/js/grids/product_characteristic_types.js' ) %]
+
+<div id="datagrid"></div>

--- a/root/src/productcharacteristictype/view.tt2
+++ b/root/src/productcharacteristictype/view.tt2
@@ -1,0 +1,12 @@
+[% META title = 'Product Characteristic Type Details' %]
+
+<script type="text/javascript">
+   var url_product_characteristic_type_load_form = '[% c.uri_for( "/productcharacteristictype/load_form" ) %]';
+   var url_product_characteristic_type_grid = '[% c.uri_for( "/productcharacteristictype/grid" ) %]';
+   
+   var product_characteristic_type_id = '[% object.product_characteristic_type_id %]';
+</script>
+
+[% js_link( src = '/static/js/grids/product_characteristic_type_view.js' ) %]
+
+<div id="datagrid"></div>

--- a/root/src/productcharacteristictype/view.tt2
+++ b/root/src/productcharacteristictype/view.tt2
@@ -2,10 +2,10 @@
 
 <script type="text/javascript">
    var url_product_characteristic_type_load_form = '[% c.uri_for( "/productcharacteristictype/load_form" ) %]';
-   var url_product_characteristic_type_grid = '[% c.uri_for( "/productcharacteristictype/grid" ) %]';
+   var url_product_characteristic_type_grid = '[% c.uri_for( "/productcharacteristictype/grid/$object.product_category_id.id" ) %]';
    var url_category_view  = '[% c.uri_for( "/productcategory/grid" ) %]';
    
-   var product_characteristic_type_id = '[% object.product_characteristic_type_id %]';
+   var product_characteristic_type_id = '[% object.id %]';
 </script>
 
 [% js_link( src = '/static/js/grids/product_characteristic_type_view.js' ) %]

--- a/root/src/productcharacteristictype/view.tt2
+++ b/root/src/productcharacteristictype/view.tt2
@@ -3,6 +3,7 @@
 <script type="text/javascript">
    var url_product_characteristic_type_load_form = '[% c.uri_for( "/productcharacteristictype/load_form" ) %]';
    var url_product_characteristic_type_grid = '[% c.uri_for( "/productcharacteristictype/grid" ) %]';
+   var url_category_view  = '[% c.uri_for( "/productcategory/grid" ) %]';
    
    var product_characteristic_type_id = '[% object.product_characteristic_type_id %]';
 </script>

--- a/root/src/productstyle/view.tt2
+++ b/root/src/productstyle/view.tt2
@@ -3,7 +3,8 @@
 <script type="text/javascript">
    var url_product_style_load_form = '[% c.uri_for( "/productstyle/load_form" ) %]';
    var url_product_style_grid = '[% c.uri_for( "/productstyle/grid/$object.product_category_id.id" ) %]';
-   
+   var url_category_view  = '[% c.uri_for( "/productcategory/grid" ) %]';
+
    var product_style_id = '[% object.id %]';
 </script>
 

--- a/root/src/salevolume/view.tt2
+++ b/root/src/salevolume/view.tt2
@@ -2,6 +2,7 @@
 
 <script type="text/javascript">
    var url_sale_volume_load_form = '[% c.uri_for( "/salevolume/load_form" ) %]';
+   var url_sale_volume_grid = '[% c.uri_for( "/salevolume/grid" ) %]';
    
    var sale_volume_id = '[% object.id %]';
 </script>

--- a/root/static/js/grids/bay_position_view.js
+++ b/root/static/js/grids/bay_position_view.js
@@ -1,0 +1,78 @@
+/*
+ * This file is part of BeerFestDB, a beer festival product management
+ * system.
+ * 
+ * Copyright (C) 2026 Tim F. Rayner
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * $Id$
+ */
+
+Ext.onReady(function(){
+
+    // Enable tooltips
+    Ext.QuickTips.init();
+
+    /* bay position form */
+    var bayPositionForm = new MyFormPanel({
+
+        url:         url_bay_position_submit,
+        title:       'Bay Position details',
+            
+        items: [
+
+            { name:           'description',
+              fieldLabel:     'Description',
+              xtype:          'textfield',
+              allowBlank:     false, },
+
+            { name:           'bay_position_id',
+              value:          bay_position_id,
+              xtype:          'hidden', },
+            
+        ],
+
+        loadUrl:     url_bay_position_load_form,
+        idParams:    { bay_position_id: bay_position_id },
+        waitMsg:     'Loading Bay Position details...',
+    });
+
+    var tabpanel = new Ext.TabPanel({
+        activeTab: 0,
+        items: [
+            { title: 'Bay Position Information',
+              layout: 'anchor',
+              items:  bayPositionForm, },
+        ],
+    });
+
+    var panel = new MyMainPanel({
+        title:  'Bay Position Details',            
+        layout: 'fit',
+        items: tabpanel,
+        tbar:
+        [
+            { text: 'Home', handler: function() { window.location = url_base; } },
+            { text: 'All Bay Positions', handler: function() { window.location = url_bay_position_grid; } },
+        ],
+    });
+    
+    var view = new Ext.Viewport({
+        layout: 'fit',
+        items:  panel,
+    });
+
+});
+

--- a/root/static/js/grids/bay_position_view.js
+++ b/root/static/js/grids/bay_position_view.js
@@ -65,7 +65,7 @@ Ext.onReady(function(){
         tbar:
         [
             { text: 'Home', handler: function() { window.location = url_base; } },
-            { text: 'All Bay Positions', handler: function() { window.location = url_bay_position_grid; } },
+            { text: 'Bay Positions', handler: function() { window.location = url_bay_position_grid; } },
         ],
     });
     

--- a/root/static/js/grids/bay_positions.js
+++ b/root/static/js/grids/bay_positions.js
@@ -1,0 +1,89 @@
+/*
+ * This file is part of BeerFestDB, a beer festival product management
+ * system.
+ * 
+ * Copyright (C) 2010 Tim F. Rayner
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * $Id$
+ */
+
+Ext.onReady(function(){
+
+    // Enable tooltips
+    Ext.QuickTips.init();
+    
+    var BayPosition = Ext.data.Record.create([
+        { name: 'bay_position_id', type: 'int' },
+        { name: 'description',        type: 'string' },
+    ]);
+
+    var store = new Ext.data.JsonStore({
+        url:        url_bay_position_list,
+        root:       'objects',
+        fields:     BayPosition
+    });
+    
+    var content_cols = [
+        { id:         'description',
+          header:     'Description',
+          dataIndex:  'description',
+          width:      150,
+          editor:     new Ext.form.TextField({
+              allowBlank:     true,
+          })},
+    ];
+
+    function viewLink (grid, record, action, row, col) {
+        var t = new Ext.XTemplate(url_base + 'bayposition/view/{bay_position_id}');
+        window.location=t.apply({bay_position_id: record.get('bay_position_id')});
+    };
+
+    function recordChanges (record) {
+        var fields = record.getChanges();
+        fields.bay_position_id = record.get( 'bay_position_id' );
+        return(fields);
+    }
+
+    var panel = new MyMainPanel({
+        title: 'All Bay Positions',
+        layout: 'fit',
+        items: new MyEditorGrid(
+            {
+                objLabel:           'Bay Position',
+                idField:            'bay_position_id',
+                autoExpandColumn:   'description',
+                store:              store,
+                contentCols:        content_cols,
+                viewLink:           viewLink,
+                deleteUrl:          url_bay_position_delete,
+                submitUrl:          url_bay_position_submit,
+                recordChanges:      recordChanges,
+            }
+        ),
+        tbar:
+        [
+            { text: 'Home',
+              handler: function() { window.location = url_base; } },
+        ],
+    });
+    
+    var view = new Ext.Viewport({
+        layout: 'fit',
+        items:  panel,
+    });
+
+});
+

--- a/root/static/js/grids/company_region_view.js
+++ b/root/static/js/grids/company_region_view.js
@@ -65,6 +65,7 @@ Ext.onReady(function(){
         tbar:
         [
             { text: 'Home', handler: function() { window.location = url_base; } },
+            { text: 'Company Regions', handler: function() { window.location = url_company_region_grid; } },
         ],
     });
     

--- a/root/static/js/grids/container_measure_view.js
+++ b/root/static/js/grids/container_measure_view.js
@@ -1,0 +1,78 @@
+/*
+ * This file is part of BeerFestDB, a beer festival product management
+ * system.
+ * 
+ * Copyright (C) 2026 Tim F. Rayner
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * $Id$
+ */
+
+Ext.onReady(function(){
+
+    // Enable tooltips
+    Ext.QuickTips.init();
+
+    /* container measure form */
+    var containerMeasureForm = new MyFormPanel({
+
+        url:         url_container_measure_submit,
+        title:       'Container Measure details',
+            
+        items: [
+
+            { name:           'description',
+              fieldLabel:     'Description',
+              xtype:          'textfield',
+              allowBlank:     false, },
+
+            { name:           'container_measure_id',
+              value:          container_measure_id,
+              xtype:          'hidden', },
+            
+        ],
+
+        loadUrl:     url_container_measure_load_form,
+        idParams:    { container_measure_id: container_measure_id },
+        waitMsg:     'Loading Container Measure details...',
+    });
+
+    var tabpanel = new Ext.TabPanel({
+        activeTab: 0,
+        items: [
+            { title: 'Container Measure Information',
+              layout: 'anchor',
+              items:  containerMeasureForm, },
+        ],
+    });
+
+    var panel = new MyMainPanel({
+        title:  'Container Measure Details',            
+        layout: 'fit',
+        items: tabpanel,
+        tbar:
+        [
+            { text: 'Home', handler: function() { window.location = url_base; } },
+            { text: 'Container Measures', handler: function() { window.location = url_container_measure_grid; } },
+        ],
+    });
+    
+    var view = new Ext.Viewport({
+        layout: 'fit',
+        items:  panel,
+    });
+
+});
+

--- a/root/static/js/grids/container_measures.js
+++ b/root/static/js/grids/container_measures.js
@@ -1,0 +1,89 @@
+/*
+ * This file is part of BeerFestDB, a beer festival product management
+ * system.
+ * 
+ * Copyright (C) 2010-2026 Tim F. Rayner
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * $Id$
+ */
+
+Ext.onReady(function(){
+
+    // Enable tooltips
+    Ext.QuickTips.init();
+    
+    var ContainerMeasure = Ext.data.Record.create([
+        { name: 'container_measure_id', type: 'int' },
+        { name: 'description',        type: 'string' },
+    ]);
+
+    var store = new Ext.data.JsonStore({
+        url:        url_container_measure_list,
+        root:       'objects',
+        fields:     ContainerMeasure
+    });
+    
+    var content_cols = [
+        { id:         'description',
+          header:     'Description',
+          dataIndex:  'description',
+          width:      150,
+          editor:     new Ext.form.TextField({
+              allowBlank:     true,
+          })},
+    ];
+
+    function viewLink (grid, record, action, row, col) {
+        var t = new Ext.XTemplate(url_base + 'containermeasure/view/{container_measure_id}');
+        window.location=t.apply({container_measure_id: record.get('container_measure_id')});
+    };
+
+    function recordChanges (record) {
+        var fields = record.getChanges();
+        fields.container_measure_id = record.get( 'container_measure_id' );
+        return(fields);
+    }
+
+    var panel = new MyMainPanel({
+        title: 'All Container Measures',
+        layout: 'fit',
+        items: new MyEditorGrid(
+            {
+                objLabel:           'Container Measure',
+                idField:            'container_measure_id',
+                autoExpandColumn:   'description',
+                store:              store,
+                contentCols:        content_cols,
+                viewLink:           viewLink,
+                deleteUrl:          url_container_measure_delete,
+                submitUrl:          url_container_measure_submit,
+                recordChanges:      recordChanges,
+            }
+        ),
+        tbar:
+        [
+            { text: 'Home',
+              handler: function() { window.location = url_base; } },
+        ],
+    });
+    
+    var view = new Ext.Viewport({
+        layout: 'fit',
+        items:  panel,
+    });
+
+});
+

--- a/root/static/js/grids/container_size_view.js
+++ b/root/static/js/grids/container_size_view.js
@@ -120,6 +120,7 @@ Ext.onReady(function(){
         tbar:
         [
             { text: 'Home', handler: function() { window.location = url_base; } },
+            { text: 'Container Sizes', handler: function() { window.location = url_container_size_grid; } },
         ],
     });
     

--- a/root/static/js/grids/countries.js
+++ b/root/static/js/grids/countries.js
@@ -1,0 +1,116 @@
+/*
+ * This file is part of BeerFestDB, a beer festival product management
+ * system.
+ * 
+ * Copyright (C) 2010 Tim F. Rayner
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * $Id$
+ */
+
+Ext.onReady(function(){
+
+    // Enable tooltips
+    Ext.QuickTips.init();
+    
+    var Country = Ext.data.Record.create([
+        { name: 'country_id',   type: 'int' },
+        { name: 'country_name', type: 'string' },
+        { name: 'country_code_iso2', type: 'string' },
+        { name: 'country_code_iso3', type: 'string' },
+        { name: 'country_code_num3', type: 'string' },
+    ]);
+
+    var store = new Ext.data.JsonStore({
+        url:        url_country_list,
+        root:       'objects',
+        fields:     Country
+    });
+    
+    var content_cols = [
+        { id:         'country_name',
+          header:     'Country Name',
+          dataIndex:  'country_name',
+          width:      150,
+          editor:     new Ext.form.TextField({
+              allowBlank:     false,
+          })},
+        { id:         'country_code_iso2',
+          header:     'ISO 3166-1 alpha-2 code',
+          dataIndex:  'country_code_iso2',
+          width:      150,
+          editor:     new Ext.form.TextField({
+              allowBlank:     false,
+              maxLength:      2,
+          })},
+        { id:         'country_code_iso3',
+          header:     'ISO 3166-1 alpha-3 code',
+          dataIndex:  'country_code_iso3',
+          width:      150,
+          editor:     new Ext.form.TextField({
+              allowBlank:     false,
+              maxLength:      3,
+          })},
+        { id:         'country_code_num3',
+          header:     'ISO 3166-1 numeric code',
+          dataIndex:  'country_code_num3',
+          width:      150,
+          editor:     new Ext.form.TextField({
+              allowBlank:     false,
+              maxLength:      3,
+          })}, 
+    ];
+
+    function viewLink (grid, record, action, row, col) {
+        var t = new Ext.XTemplate(url_base + 'country/view/{country_id}');
+        window.location=t.apply({country_id: record.get('country_id')});
+    };
+
+    function recordChanges (record) {
+        var fields = record.getChanges();
+        fields.country_id = record.get( 'country_id' );
+        return(fields);
+    }
+
+    var panel = new MyMainPanel({
+        title: 'All Countries',
+        layout: 'fit',
+        items: new MyEditorGrid(
+            {
+                objLabel:           'Country',
+                idField:            'country_id',
+                autoExpandColumn:   'country_name',
+                store:              store,
+                contentCols:        content_cols,
+                viewLink:           viewLink,
+                deleteUrl:          url_country_delete,
+                submitUrl:          url_country_submit,
+                recordChanges:      recordChanges,
+            }
+        ),
+        tbar:
+        [
+            { text: 'Home',
+              handler: function() { window.location = url_base; } },
+        ],
+    });
+    
+    var view = new Ext.Viewport({
+        layout: 'fit',
+        items:  panel,
+    });
+
+});
+

--- a/root/static/js/grids/country_view.js
+++ b/root/static/js/grids/country_view.js
@@ -1,0 +1,96 @@
+/*
+ * This file is part of BeerFestDB, a beer festival product management
+ * system.
+ * 
+ * Copyright (C) 2026 Tim F. Rayner
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * $Id$
+ */
+
+Ext.onReady(function(){
+
+    // Enable tooltips
+    Ext.QuickTips.init();
+
+    /* country form */
+    var countryForm = new MyFormPanel({
+
+        url:         url_country_submit,
+        title:       'Country details',
+            
+        items: [
+
+            { name:           'country_name',
+              fieldLabel:     'Country Name',
+              xtype:          'textfield',
+              allowBlank:     false, },
+
+            { name:           'country_code_iso2',
+              fieldLabel:     'ISO 3166-1 alpha-2 code',
+              xtype:          'textfield',
+              maxLength:      2,
+              allowBlank:     false, },
+
+            { name:           'country_code_iso3',
+              fieldLabel:     'ISO 3166-1 alpha-3 code',
+              xtype:          'textfield',
+              maxLength:      3,
+              allowBlank:     false, },
+
+            { name:           'country_code_num3',
+              fieldLabel:     'ISO 3166-1 numeric code',
+              xtype:          'textfield',
+              maxLength:      3,
+              allowBlank:     false, },
+
+            { name:           'country_id',
+              value:          country_id,
+              xtype:          'hidden', },
+            
+        ],
+
+        loadUrl:     url_country_load_form,
+        idParams:    { country_id: country_id },
+        waitMsg:     'Loading Country details...',
+    });
+
+    var tabpanel = new Ext.TabPanel({
+        activeTab: 0,
+        items: [
+            { title: 'Country Information',
+              layout: 'anchor',
+              items:  countryForm, },
+        ],
+    });
+
+    var panel = new MyMainPanel({
+        title:  'Country Details',            
+        layout: 'fit',
+        items: tabpanel,
+        tbar:
+        [
+            { text: 'Home', handler: function() { window.location = url_base; } },
+            { text: 'Countries', handler: function() { window.location = url_country_grid; } },
+        ],
+    });
+    
+    var view = new Ext.Viewport({
+        layout: 'fit',
+        items:  panel,
+    });
+
+});
+

--- a/root/static/js/grids/currencies.js
+++ b/root/static/js/grids/currencies.js
@@ -1,0 +1,129 @@
+/*
+ * This file is part of BeerFestDB, a beer festival product management
+ * system.
+ * 
+ * Copyright (C) 2010 Tim F. Rayner
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * $Id$
+ */
+
+Ext.onReady(function(){
+
+    // Enable tooltips
+    Ext.QuickTips.init();
+    
+    var Currency = Ext.data.Record.create([
+        { name: 'currency_id',            type: 'int' },
+        { name: 'currency_code',          type: 'string' },
+        { name: 'currency_number',        type: 'string' },
+        { name: 'currency_format',        type: 'string' },
+        { name: 'exponent',               type: 'int' },
+        { name: 'currency_symbol',        type: 'string' },
+    ]);
+
+    var store = new Ext.data.JsonStore({
+        url:        url_currency_list,
+        root:       'objects',
+        fields:     Currency
+    });
+    
+    var content_cols = [
+        { id:         'currency_code',
+          header:     'Currency Code',
+          dataIndex:  'currency_code',
+          width:      150,
+          editor:     new Ext.form.TextField({
+              allowBlank:     false,
+              maxLength:      3,
+          })},
+        { id:         'currency_number',
+          header:     'Currency Number',
+          dataIndex:  'currency_number',
+          width:      150,
+          editor:     new Ext.form.TextField({
+              allowBlank:     false,
+              maxLength:      3,
+          })},
+        { id:         'currency_format',
+          header:     'Currency Format',
+          dataIndex:  'currency_format',
+          width:      150,
+          editor:     new Ext.form.TextField({
+              allowBlank:     false,
+              maxLength:      20,
+          })},
+        { id:         'exponent',
+          header:     'Exponent',
+          dataIndex:  'exponent',
+          width:      150,
+          editor:     new Ext.form.NumberField({
+              allowBlank:     false,
+              allowDecimals:  false,
+              allowNegative:  false,
+              minValue:       0,
+              maxValue:       10,
+          })},
+        { id:         'currency_symbol',
+          header:     'Currency Symbol',
+          dataIndex:  'currency_symbol',
+          width:      150,
+          editor:     new Ext.form.TextField({
+              allowBlank:     false,
+              maxLength:      10,
+          })},
+    ];
+
+    function viewLink (grid, record, action, row, col) {
+        var t = new Ext.XTemplate(url_base + 'currency/view/{currency_id}');
+        window.location=t.apply({currency_id: record.get('currency_id')});
+    };
+
+    function recordChanges (record) {
+        var fields = record.getChanges();
+        fields.currency_id = record.get( 'currency_id' );
+        return(fields);
+    }
+
+    var panel = new MyMainPanel({
+        title: 'All Currencies',
+        layout: 'fit',
+        items: new MyEditorGrid(
+            {
+                objLabel:           'Currency',
+                idField:            'currency_id',
+                autoExpandColumn:   'currency_code',
+                store:              store,
+                contentCols:        content_cols,
+                viewLink:           viewLink,
+                deleteUrl:          url_currency_delete,
+                submitUrl:          url_currency_submit,
+                recordChanges:      recordChanges,
+            }
+        ),
+        tbar:
+        [
+            { text: 'Home',
+              handler: function() { window.location = url_base; } },
+        ],
+    });
+    
+    var view = new Ext.Viewport({
+        layout: 'fit',
+        items:  panel,
+    });
+
+});
+

--- a/root/static/js/grids/currency_view.js
+++ b/root/static/js/grids/currency_view.js
@@ -1,0 +1,106 @@
+/*
+ * This file is part of BeerFestDB, a beer festival product management
+ * system.
+ * 
+ * Copyright (C) 2026 Tim F. Rayner
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * $Id$
+ */
+
+Ext.onReady(function(){
+
+    // Enable tooltips
+    Ext.QuickTips.init();
+
+    /* currency form */
+    var currencyForm = new MyFormPanel({
+
+        url:         url_currency_submit,
+        title:       'Currency details',
+            
+        items: [
+
+            { name:           'currency_code',
+              fieldLabel:     'Currency Code',
+              xtype:          'textfield',
+              maxLength:      3,
+              allowBlank:     false, },
+
+            { name:           'currency_number',
+              fieldLabel:     'Currency Number',
+              xtype:          'textfield',
+              maxLength:      3,
+              allowBlank:     false, },
+
+            { name:           'currency_format',
+              fieldLabel:     'Currency Format',
+              xtype:          'textfield',
+              maxLength:      20,
+              allowBlank:     false, },
+
+            { name:           'exponent',
+              fieldLabel:     'Exponent',
+              xtype:          'numberfield',
+              allowDecimals:  false,
+              allowNegative:  false,
+              minValue:       0,
+              maxValue:       10,
+              allowBlank:     false, },
+
+            { name:           'currency_symbol',
+              fieldLabel:     'Currency Symbol',
+              xtype:          'textfield',
+              maxLength:      10,
+              allowBlank:     false, },
+
+            { name:           'currency_id',
+              value:          currency_id,
+              xtype:          'hidden', },
+            
+        ],
+
+        loadUrl:     url_currency_load_form,
+        idParams:    { currency_id: currency_id },
+        waitMsg:     'Loading Currency details...',
+    });
+
+    var tabpanel = new Ext.TabPanel({
+        activeTab: 0,
+        items: [
+            { title: 'Currency Information',
+              layout: 'anchor',
+              items:  currencyForm, },
+        ],
+    });
+
+    var panel = new MyMainPanel({
+        title:  'Currency Details',            
+        layout: 'fit',
+        items: tabpanel,
+        tbar:
+        [
+            { text: 'Home', handler: function() { window.location = url_base; } },
+            { text: 'Currencies', handler: function() { window.location = url_currency_grid; } },
+        ],
+    });
+    
+    var view = new Ext.Viewport({
+        layout: 'fit',
+        items:  panel,
+    });
+
+});
+

--- a/root/static/js/grids/dispense_method_view.js
+++ b/root/static/js/grids/dispense_method_view.js
@@ -65,6 +65,7 @@ Ext.onReady(function(){
         tbar:
         [
             { text: 'Home', handler: function() { window.location = url_base; } },
+            { text: 'Dispense Methods', handler: function() { window.location = url_dispense_method_grid; } },
         ],
     });
     

--- a/root/static/js/grids/product_allergen_type_view.js
+++ b/root/static/js/grids/product_allergen_type_view.js
@@ -65,6 +65,7 @@ Ext.onReady(function(){
         tbar:
         [
             { text: 'Home', handler: function() { window.location = url_base; } },
+            { text: 'Product Allergen Types', handler: function() { window.location = url_product_allergen_type_grid; } },
         ],
     });
     

--- a/root/static/js/grids/product_category_view.js
+++ b/root/static/js/grids/product_category_view.js
@@ -1,0 +1,184 @@
+/*
+ * This file is part of BeerFestDB, a beer festival product management
+ * system.
+ * 
+ * Copyright (C) 2026 Tim F. Rayner
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * $Id$
+ */
+
+Ext.onReady(function(){
+
+    // Enable tooltips
+    Ext.QuickTips.init();
+
+    var ProductStyle = Ext.data.Record.create([
+        { name: 'product_style_id',    type: 'int' },
+        { name: 'product_category_id', type: 'int' },
+        { name: 'description',         type: 'string' },
+    ]);
+
+    var style_store = new Ext.data.JsonStore({
+        url:        url_product_style_list,
+        root:       'objects',
+        fields:     ProductStyle,
+	    idProperty: 'product_style_id',
+        sortInfo:   {
+            field:     'description',
+            direction: 'ASC',
+        },
+    });
+    
+    /* Style grid */
+    var styleGrid = new MyEditorGrid(
+        {
+            objLabel:           'Product Style',
+            idField:            'product_style_id',
+            autoExpandColumn:   'description',
+            deleteUrl:          url_productstyle_delete,
+            submitUrl:          url_productstyle_submit,
+            recordChanges:      function (record) {
+                var fields = record.getChanges();
+                fields.product_style_id    = record.get( 'product_style_id' );
+                fields.product_category_id = product_category_id;
+                return(fields);
+            },
+            store:              style_store,
+            contentCols: [
+                { id:        'description',
+                  header:    'Style Name',
+                  dataIndex: 'description',
+                  width:      150,
+                  editor:     new Ext.form.TextField({
+                      allowBlank: false,
+                  })},
+            ],
+            viewLink: function (grid, record, action, row, col) {
+                var t = new Ext.XTemplate(url_base + 'productstyle/view/{product_style_id}');
+                window.location=t.apply({
+                    product_style_id: record.get('product_style_id'),
+                })
+            },
+        }
+    );
+    
+    var ProductCharacteristicType = Ext.data.Record.create([
+        { name: 'product_characteristic_type_id',    type: 'int' },
+        { name: 'product_category_id', type: 'int' },
+        { name: 'description',         type: 'string' },
+    ]);
+
+    var characteristic_store = new Ext.data.JsonStore({
+        url:        url_product_characteristic_type_list,
+        root:       'objects',
+        fields:     ProductCharacteristicType,
+	    idProperty: 'product_characteristic_type_id',
+        sortInfo:   {
+            field:     'description',
+            direction: 'ASC',
+        },
+    });
+    
+    /* Characteristic grid */
+    var characteristicGrid = new MyEditorGrid(
+        {
+            objLabel:           'Product Characteristic Type',
+            idField:            'product_characteristic_type_id',
+            autoExpandColumn:   'description',
+            deleteUrl:          url_product_characteristic_type_delete,
+            submitUrl:          url_product_characteristic_type_submit,
+            recordChanges:      function (record) {
+                var fields = record.getChanges();
+                fields.product_characteristic_type_id    = record.get( 'product_characteristic_type_id' );
+                fields.product_category_id = product_category_id;
+                return(fields);
+            },
+            store:              characteristic_store,
+            contentCols: [
+                { id:        'description',
+                  header:    'Characteristic Name',
+                  dataIndex: 'description',
+                  width:      150,
+                  editor:     new Ext.form.TextField({
+                      allowBlank: false,
+                  })},
+            ],
+            viewLink: function (grid, record, action, row, col) {
+                var t = new Ext.XTemplate(url_base + 'productcharacteristictype/view/{product_characteristic_type_id}');
+                window.location=t.apply({
+                    product_characteristic_type_id: record.get('product_characteristic_type_id'),
+                })
+            },
+        }
+    );
+    
+    /* product category form */
+    var productCategoryForm = new MyFormPanel({
+
+        url:         url_product_category_submit,
+        title:       'Product Category details',
+            
+        items: [
+
+            { name:           'description',
+              fieldLabel:     'Description',
+              xtype:          'textfield',
+              allowBlank:     false, },
+
+            { name:           'product_category_id',
+              value:          product_category_id,
+              xtype:          'hidden', },
+            
+        ],
+
+        loadUrl:     url_product_category_load_form,
+        idParams:    { product_category_id: product_category_id },
+        waitMsg:     'Loading Product Category details...',
+    });
+
+    var tabpanel = new Ext.TabPanel({
+        activeTab: 0,
+        items: [
+            { title: 'Product Category Information',
+              layout: 'anchor',
+              items:  productCategoryForm, },
+            { title: 'Product Styles',
+              layout: 'fit',
+              items:  styleGrid, },
+            { title: 'Product Characteristic Types',
+              layout: 'fit',
+              items:  characteristicGrid, },
+        ],
+    });
+
+    var panel = new MyMainPanel({
+        title:  'Product Category Details',            
+        layout: 'fit',
+        items: tabpanel,
+        tbar:
+        [
+            { text: 'Home', handler: function() { window.location = url_base; } },
+            { text: 'Product Categories', handler: function() { window.location = url_product_category_grid; } },
+        ],
+    });
+    
+    var view = new Ext.Viewport({
+        layout: 'fit',
+        items:  panel,
+    });
+
+});
+

--- a/root/static/js/grids/product_characteristic_type_view.js
+++ b/root/static/js/grids/product_characteristic_type_view.js
@@ -65,7 +65,8 @@ Ext.onReady(function(){
         tbar:
         [
             { text: 'Home', handler: function() { window.location = url_base; } },
-            { text: 'Product Characteristic Types', handler: function() { window.location = url_product_characteristic_type_grid; } },
+            { text: 'Product Categories', handler: function() { window.location = url_category_view; } },
+            { text: 'Characteristic Types', handler: function() { window.location = url_product_characteristic_type_grid; } },
         ],
     });
     

--- a/root/static/js/grids/product_characteristic_type_view.js
+++ b/root/static/js/grids/product_characteristic_type_view.js
@@ -66,7 +66,7 @@ Ext.onReady(function(){
         [
             { text: 'Home', handler: function() { window.location = url_base; } },
             { text: 'Product Categories', handler: function() { window.location = url_category_view; } },
-            { text: 'Characteristic Types', handler: function() { window.location = url_product_characteristic_type_grid; } },
+            { text: 'Product Characteristic Types', handler: function() { window.location = url_product_characteristic_type_grid; } },
         ],
     });
     

--- a/root/static/js/grids/product_characteristic_type_view.js
+++ b/root/static/js/grids/product_characteristic_type_view.js
@@ -1,0 +1,78 @@
+/*
+ * This file is part of BeerFestDB, a beer festival product management
+ * system.
+ * 
+ * Copyright (C) 2026 Tim F. Rayner
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * $Id$
+ */
+
+Ext.onReady(function(){
+
+    // Enable tooltips
+    Ext.QuickTips.init();
+
+    /* product characteristic type form */
+    var productCharacteristicTypeForm = new MyFormPanel({
+
+        url:         url_product_characteristic_type_submit,
+        title:       'Product Characteristic Type details',
+            
+        items: [
+
+            { name:           'description',
+              fieldLabel:     'Description',
+              xtype:          'textfield',
+              allowBlank:     false, },
+
+            { name:           'product_characteristic_type_id',
+              value:          product_characteristic_type_id,
+              xtype:          'hidden', },
+            
+        ],
+
+        loadUrl:     url_product_characteristic_type_load_form,
+        idParams:    { product_characteristic_type_id: product_characteristic_type_id },
+        waitMsg:     'Loading Product Characteristic Type details...',
+    });
+
+    var tabpanel = new Ext.TabPanel({
+        activeTab: 0,
+        items: [
+            { title: 'Product Characteristic Type Information',
+              layout: 'anchor',
+              items:  productCharacteristicTypeForm, },
+        ],
+    });
+
+    var panel = new MyMainPanel({
+        title:  'Product Characteristic Type Details',            
+        layout: 'fit',
+        items: tabpanel,
+        tbar:
+        [
+            { text: 'Home', handler: function() { window.location = url_base; } },
+            { text: 'Product Characteristic Types', handler: function() { window.location = url_product_characteristic_type_grid; } },
+        ],
+    });
+    
+    var view = new Ext.Viewport({
+        layout: 'fit',
+        items:  panel,
+    });
+
+});
+

--- a/root/static/js/grids/product_characteristic_types.js
+++ b/root/static/js/grids/product_characteristic_types.js
@@ -25,15 +25,42 @@ Ext.onReady(function(){
     // Enable tooltips
     Ext.QuickTips.init();
     
+    var category_store = new Ext.data.JsonStore({
+        url:        url_category_list,
+        root:       'objects',
+        fields:     [{ name: 'product_category_id', type: 'int' },
+                     { name: 'description',          type: 'string'}],
+        idProperty: 'product_category_id',
+        sortInfo:   {
+            field:     'description',
+            direction: 'ASC',
+        },
+    });
+
     var ProductCharacteristicType = Ext.data.Record.create([
         { name: 'product_characteristic_type_id', type: 'int' },
-        { name: 'description',        type: 'string' },
+        { name: 'product_category_id',            type: 'int' },
+        { name: 'description',                    type: 'string' },
     ]);
 
     var store = new Ext.data.JsonStore({
         url:        url_product_characteristic_type_list,
         root:       'objects',
         fields:     ProductCharacteristicType
+    });
+
+    var category_combo = new Ext.form.ComboBox({
+        typeAhead:      true,
+        triggerAction:  'all',
+        mode:           'local',
+        allowBlank:     true,
+        noSelection:    emptySelect,
+        forceSelection: true,
+        store:          category_store,
+        valueField:     'product_category_id',
+        displayField:   'description',
+        lazyRender:     true,
+        listClass:      'x-combo-list-small',
     });
     
     var content_cols = [
@@ -44,6 +71,13 @@ Ext.onReady(function(){
           editor:     new Ext.form.TextField({
               allowBlank:     true,
           })},
+        { id:         'product_category_id',
+          header:     'Product Category',
+          dataIndex:  'product_category_id',
+          width:      150,
+          renderer:    MyComboRenderer(category_combo),
+          editor:      category_combo,
+        },
     ];
 
     function viewLink (grid, record, action, row, col) {
@@ -66,6 +100,7 @@ Ext.onReady(function(){
                 idField:            'product_characteristic_type_id',
                 autoExpandColumn:   'description',
                 store:              store,
+                comboStores:        [ category_store ],
                 contentCols:        content_cols,
                 viewLink:           viewLink,
                 deleteUrl:          url_product_characteristic_type_delete,

--- a/root/static/js/grids/product_characteristic_types.js
+++ b/root/static/js/grids/product_characteristic_types.js
@@ -25,18 +25,6 @@ Ext.onReady(function(){
     // Enable tooltips
     Ext.QuickTips.init();
     
-    var category_store = new Ext.data.JsonStore({
-        url:        url_category_list,
-        root:       'objects',
-        fields:     [{ name: 'product_category_id', type: 'int' },
-                     { name: 'description',          type: 'string'}],
-        idProperty: 'product_category_id',
-        sortInfo:   {
-            field:     'description',
-            direction: 'ASC',
-        },
-    });
-
     var ProductCharacteristicType = Ext.data.Record.create([
         { name: 'product_characteristic_type_id', type: 'int' },
         { name: 'product_category_id',            type: 'int' },
@@ -44,25 +32,11 @@ Ext.onReady(function(){
     ]);
 
     var store = new Ext.data.JsonStore({
-        url:        url_product_characteristic_type_list,
+        url:        url_object_list,
         root:       'objects',
         fields:     ProductCharacteristicType
     });
 
-    var category_combo = new Ext.form.ComboBox({
-        typeAhead:      true,
-        triggerAction:  'all',
-        mode:           'local',
-        allowBlank:     true,
-        noSelection:    emptySelect,
-        forceSelection: true,
-        store:          category_store,
-        valueField:     'product_category_id',
-        displayField:   'description',
-        lazyRender:     true,
-        listClass:      'x-combo-list-small',
-    });
-    
     var content_cols = [
         { id:         'description',
           header:     'Description',
@@ -71,13 +45,6 @@ Ext.onReady(function(){
           editor:     new Ext.form.TextField({
               allowBlank:     true,
           })},
-        { id:         'product_category_id',
-          header:     'Product Category',
-          dataIndex:  'product_category_id',
-          width:      150,
-          renderer:    MyComboRenderer(category_combo),
-          editor:      category_combo,
-        },
     ];
 
     function viewLink (grid, record, action, row, col) {
@@ -100,7 +67,6 @@ Ext.onReady(function(){
                 idField:            'product_characteristic_type_id',
                 autoExpandColumn:   'description',
                 store:              store,
-                comboStores:        [ category_store ],
                 contentCols:        content_cols,
                 viewLink:           viewLink,
                 deleteUrl:          url_product_characteristic_type_delete,

--- a/root/static/js/grids/product_characteristic_types.js
+++ b/root/static/js/grids/product_characteristic_types.js
@@ -25,20 +25,20 @@ Ext.onReady(function(){
     // Enable tooltips
     Ext.QuickTips.init();
     
-    var ProductCategory = Ext.data.Record.create([
-        { name: 'product_category_id',  type: 'int' },
-        { name: 'description',          type: 'string' },
+    var ProductCharacteristicType = Ext.data.Record.create([
+        { name: 'product_characteristic_type_id', type: 'int' },
+        { name: 'description',        type: 'string' },
     ]);
 
     var store = new Ext.data.JsonStore({
-        url:        url_category_list,
+        url:        url_product_characteristic_type_list,
         root:       'objects',
-        fields:     ProductCategory
+        fields:     ProductCharacteristicType
     });
     
     var content_cols = [
         { id:         'description',
-          header:     'Category Name',
+          header:     'Description',
           dataIndex:  'description',
           width:      150,
           editor:     new Ext.form.TextField({
@@ -47,35 +47,38 @@ Ext.onReady(function(){
     ];
 
     function viewLink (grid, record, action, row, col) {
-        var t = new Ext.XTemplate(url_base + 'productcategory/view/{product_category_id}');
-        window.location=t.apply({product_category_id: record.get('product_category_id')});
+        var t = new Ext.XTemplate(url_base + 'productcharacteristictype/view/{product_characteristic_type_id}');
+        window.location=t.apply({product_characteristic_type_id: record.get('product_characteristic_type_id')});
     };
 
     function recordChanges (record) {
         var fields = record.getChanges();
-        fields.product_category_id = record.get( 'product_category_id' );
+        fields.product_characteristic_type_id = record.get( 'product_characteristic_type_id' );
         return(fields);
     }
 
     var panel = new MyMainPanel({
-        title: 'All Product Categories',
+        title: 'All Product Characteristic Types',
         layout: 'fit',
         items: new MyEditorGrid(
             {
-                objLabel:           'Product Category',
-                idField:            'product_category_id',
+                objLabel:           'Product Characteristic Type',
+                idField:            'product_characteristic_type_id',
                 autoExpandColumn:   'description',
                 store:              store,
                 contentCols:        content_cols,
                 viewLink:           viewLink,
-                deleteUrl:          url_category_delete,
-                submitUrl:          url_category_submit,
+                deleteUrl:          url_product_characteristic_type_delete,
+                submitUrl:          url_product_characteristic_type_submit,
                 recordChanges:      recordChanges,
             }
         ),
         tbar:
         [
-            { text: 'Home', handler: function() { window.location = url_base; } },
+            { text: 'Home',
+              handler: function() { window.location = url_base; } },
+            { text: 'Product Categories',
+              handler: function() { window.location = url_category_view; } },
         ],
     });
     

--- a/root/static/js/grids/product_style_view.js
+++ b/root/static/js/grids/product_style_view.js
@@ -65,7 +65,8 @@ Ext.onReady(function(){
         tbar:
         [
             { text: 'Home', handler: function() { window.location = url_base; } },
-            { text: 'Product Category Styles', handler: function() { window.location = url_product_style_grid; } },
+            { text: 'Product Categories', handler: function() { window.location = url_category_view; } },
+            { text: 'Product Styles', handler: function() { window.location = url_product_style_grid; } },
         ],
     });
     

--- a/root/static/js/grids/sale_volume_view.js
+++ b/root/static/js/grids/sale_volume_view.js
@@ -96,6 +96,7 @@ Ext.onReady(function(){
         tbar:
         [
             { text: 'Home', handler: function() { window.location = url_base; } },
+            { text: 'Sale Volumes', handler: function() { window.location = url_sale_volume_grid; } },
         ],
     });
     

--- a/t/controllers.t
+++ b/t/controllers.t
@@ -50,6 +50,7 @@ use_ok $_ for qw(
     BeerFestDB::Web::Controller::Product
     BeerFestDB::Web::Controller::ProductAllergenType
     BeerFestDB::Web::Controller::ProductCategory
+    BeerFestDB::Web::Controller::ProductCharacteristicType
     BeerFestDB::Web::Controller::ProductOrder
     BeerFestDB::Web::Controller::ProductStyle
     BeerFestDB::Web::Controller::Role
@@ -266,6 +267,17 @@ subtest 'ProductAllergenType' => sub {
 # ---------------------------------------------------------------------------
 subtest 'ProductCategory' => sub {
     generic_grid_tests("productcategory", "ProductCategory", $admin);
+};
+
+# ---------------------------------------------------------------------------
+subtest 'ProductCharacteristicType' => sub {
+    generic_grid_tests("productcharacteristictype", "ProductCharacteristicType", $admin);
+    $admin->get_ok('/productcharacteristictype/view/1',              'view should succeed');
+    $admin->get_ok('/productcharacteristictype/load_form',           'load_form should succeed');
+    $admin->get_ok('/productcharacteristictype/list_by_category/2',  'list_by_category should succeed');
+    # Needs JSON payload / confirmation:
+    #$admin->get_ok('/productcharacteristictype/submit',             'submit should succeed');
+    #$admin->get_ok('/productcharacteristictype/delete',             'delete should succeed');
 };
 
 # ---------------------------------------------------------------------------

--- a/t/lib/TestFestivalDB.pm
+++ b/t/lib/TestFestivalDB.pm
@@ -87,6 +87,11 @@ BEGIN {
                               contact_id => 1,
                               local_number => "0123456789"});
 
+        $schema->resultset("ProductCharacteristicType")
+            ->find_or_create({product_characteristic_type_id => 1,
+                              product_category_id => 2, # Foreign beer
+                              description => "TestCharacteristic"});
+
         $schema->resultset("Product")
             ->find_or_create({product_id => 1,
                               company_id => 1,


### PR DESCRIPTION
Closes #72 

Additional changes:

- Reworked navigation for the admin pages around product category, styles, characteristics
- ProductCharacteristicType primary database ID is now just product_characteristic_type_id (was a compound key of this plus product_category_id, which was making managing changes tricky).
- ProductCharacteristic value is now varchar(32) instead of int() because we want to store more complex data types
- These changes will require running the new DB migration script when deploying in production
- Redesign of landing page

TODO

- [x] review design of ProductCharacteristicType grid. Should probably filter on ProductCategory in the same way that the ProductStyle grid does.