### PR TITLE
31 advanced dump to template filters

### DIFF
--- a/lib/BeerFestDB/Dumper/Template.pm
+++ b/lib/BeerFestDB/Dumper/Template.pm
@@ -63,6 +63,11 @@ has 'filters'    => ( is       => 'ro',
                       required => 1,
                       default  => sub { [] } );
 
+has 'include_filters' => ( is       => 'ro',
+                           isa      => 'ArrayRef',
+                           required => 1,
+                           default  => sub { [] } );
+
 has 'dump_class'  => ( is       => 'ro',
                        isa      => 'Str',
                        required => 1,
@@ -387,6 +392,21 @@ sub is_user_filtered {
     return 0;
 }
 
+sub is_user_included {
+
+    my ( $self, $objhash ) = @_;
+
+    # Include filters are stored as an arrayref of arrayrefs.
+    foreach my $filter ( @{ $self->include_filters } ) {
+        my ( $key, $value, $count ) = @$filter;
+        if ( exists($objhash->{ $key }) && $objhash->{ $key } eq $value ) {
+            $filter->[2]++;
+            return 1;
+        }
+    }
+    return 0;
+}
+
 sub dump {
 
     my ( $self ) = @_;
@@ -486,16 +506,34 @@ sub dump {
         confess(sprintf(qq{Attempt to dump data from unsupported class "%s"}, $self->dump_class));
     }
 
-    # The user may have specified some object properties to filter out of the dump.
-    @template_data = grep { ! $self->is_user_filtered($_) } @template_data;
+    # The user may have specified include and/or exclude filters.
+    # Include filters act as a whitelist; if an item matches any include filter
+    # it is always kept, even if it also matches an exclude filter (include has
+    # priority).  If include filters are specified and an item matches none of
+    # them, it is dropped regardless of the exclude filters.  If no include
+    # filters are specified the original exclude-only behaviour is preserved.
+    my $has_includes = scalar @{ $self->include_filters };
+    my $keep = sub {
+        my ($h) = @_;
+        return 1 if $has_includes && $self->is_user_included($h);  # explicit include always wins
+        return 0 if $has_includes && ! $self->is_user_included($h); # outside whitelist
+        return ! $self->is_user_filtered($h);                       # no whitelist: exclude-only
+    };
+    @template_data = grep { $keep->($_) } @template_data;
     foreach my $stillage_name ( keys %stillage ) {
-        $stillage{ $stillage_name } = [ grep { ! $self->is_user_filtered($_) }
+        $stillage{ $stillage_name } = [ grep { $keep->($_) }
                                             @{ $stillage{ $stillage_name } } ];
     }
     foreach my $filter ( @{ $self->filters } ) {
         my ( $key, $value, $count ) = @$filter;
         if ( (not defined($count)) || $count == 0 ) {
-            warn("Warning: Filter expression did not remove any entries: $key=$value\n");
+            warn("Warning: Exclude filter expression did not remove any entries: $key=$value\n");
+        }
+    }
+    foreach my $filter ( @{ $self->include_filters } ) {
+        my ( $key, $value, $count ) = @$filter;
+        if ( (not defined($count)) || $count == 0 ) {
+            warn("Warning: Include filter expression did not match any entries: $key=$value\n");
         }
     }
 

--- a/t/dumper_template_filters.t
+++ b/t/dumper_template_filters.t
@@ -1,0 +1,147 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+use File::Temp qw(tempfile);
+use IO::File;
+
+use lib 't/lib';
+use TestFestivalDB qw(schema);
+
+BEGIN { use_ok 'BeerFestDB::Dumper::Template' }
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# A minimal TT template: one product name per line.
+my ( undef, $tt_file ) = tempfile( SUFFIX => '.tt2', UNLINK => 1 );
+{
+    open my $fh, '>', $tt_file or die "Cannot write template: $!";
+    print $fh "[% FOREACH item IN objects %][% item.product %]\n[% END %]";
+    close $fh;
+}
+
+sub make_dumper {
+    my ( $out_file, %filter_opts ) = @_;
+    my $fh = IO::File->new( $out_file, '>' ) or die "Cannot open $out_file: $!";
+    return BeerFestDB::Dumper::Template->new(
+        database   => schema(),
+        template   => $tt_file,
+        dump_class => 'cask',
+        filehandle => $fh,
+        %filter_opts,
+    );
+}
+
+sub run_dump {
+    my (%filter_opts) = @_;
+    my ( undef, $out_file ) = tempfile( SUFFIX => '.out', UNLINK => 1 );
+    my $dumper = make_dumper( $out_file, %filter_opts );
+    my $fh = $dumper->filehandle;
+    $dumper->dump();
+    $fh->close;
+    open my $rfh, '<', $out_file or die "Cannot read $out_file: $!";
+    return do { local $/; <$rfh> };
+}
+
+# ---------------------------------------------------------------------------
+# Unit tests: is_user_filtered
+# ---------------------------------------------------------------------------
+
+subtest 'is_user_filtered' => sub {
+    my $d = BeerFestDB::Dumper::Template->new(
+        database => schema(),
+        template => $tt_file,
+        filters  => [ [ 'category', 'ale' ], [ 'brewery', 'ACME' ] ],
+    );
+
+    my $obj_cat   = { category => 'ale',   product => 'Bitter'  };
+    my $obj_brew  = { brewery  => 'ACME',  product => 'Lager'   };
+    my $obj_none  = { category => 'cider', brewery => 'Other',
+                      product  => 'Scrumpy' };
+
+    ok(  $d->is_user_filtered($obj_cat),  'is_user_filtered: true when category matches'  );
+    ok(  $d->is_user_filtered($obj_brew), 'is_user_filtered: true when brewery matches'   );
+    ok( !$d->is_user_filtered($obj_none), 'is_user_filtered: false when nothing matches'  );
+
+    # The count slot [2] of the matching filter tuple is incremented.
+    my $filter = $d->filters->[0];   # [ 'category', 'ale', ... ]
+    $d->is_user_filtered($obj_cat);  # increment count
+    ok( ($filter->[2] // 0) > 0, 'is_user_filtered: matching increments filter count' );
+};
+
+# ---------------------------------------------------------------------------
+# Unit tests: is_user_included
+# ---------------------------------------------------------------------------
+
+subtest 'is_user_included' => sub {
+    my $d = BeerFestDB::Dumper::Template->new(
+        database        => schema(),
+        template        => $tt_file,
+        include_filters => [ [ 'category', 'ale' ], [ 'brewery', 'TestBrewer' ] ],
+    );
+
+    my $obj_cat   = { category => 'ale',         product => 'Bitter'   };
+    my $obj_brew  = { brewery  => 'TestBrewer',   product => 'TestBeer' };
+    my $obj_none  = { category => 'cider',  brewery => 'Other',
+                      product  => 'Scrumpy' };
+
+    ok(  $d->is_user_included($obj_cat),  'is_user_included: true when category matches'  );
+    ok(  $d->is_user_included($obj_brew), 'is_user_included: true when brewery matches'   );
+    ok( !$d->is_user_included($obj_none), 'is_user_included: false when nothing matches'  );
+
+    # The count slot [2] of the matching include_filter tuple is incremented.
+    my $filter = $d->include_filters->[0];  # [ 'category', 'ale', ... ]
+    $d->is_user_included($obj_cat);         # increment count
+    ok( ($filter->[2] // 0) > 0, 'is_user_included: matching increments filter count' );
+};
+
+# ---------------------------------------------------------------------------
+# Integration tests: dump() filter priority
+#
+# The test DB has exactly one cask: TestBeer (brewery=TestBrewer,
+# category=Foreign beer).  The five subtests cover every branch of the
+# $keep closure in BeerFestDB::Dumper::Template::dump().
+# ---------------------------------------------------------------------------
+
+subtest 'dump(): no filters — item included' => sub {
+    my $output = run_dump();
+    like( $output, qr/TestBeer/,
+          'no filters: TestBeer appears in output' );
+};
+
+subtest 'dump(): matching exclude filter — item excluded' => sub {
+    my $output = run_dump(
+        filters => [ [ 'brewery', 'TestBrewer' ] ],
+    );
+    unlike( $output, qr/TestBeer/,
+            'exclude match: TestBeer absent from output' );
+};
+
+subtest 'dump(): matching include filter — item included' => sub {
+    my $output = run_dump(
+        include_filters => [ [ 'brewery', 'TestBrewer' ] ],
+    );
+    like( $output, qr/TestBeer/,
+          'include match: TestBeer present in output' );
+};
+
+subtest 'dump(): include and exclude both match — include has priority' => sub {
+    my $output = run_dump(
+        include_filters => [ [ 'brewery', 'TestBrewer' ] ],
+        filters         => [ [ 'brewery', 'TestBrewer' ] ],
+    );
+    like( $output, qr/TestBeer/,
+          'include wins over exclude: TestBeer still present in output' );
+};
+
+subtest 'dump(): include whitelist set but item not matched — item excluded' => sub {
+    my $output = run_dump(
+        include_filters => [ [ 'brewery', 'SomeOtherBrewery' ] ],
+    );
+    unlike( $output, qr/TestBeer/,
+            'whitelist miss: TestBeer absent when include filter set but does not match' );
+};
+
+done_testing;

--- a/util/dump_to_template.pl
+++ b/util/dump_to_template.pl
@@ -54,7 +54,7 @@ sub parse_idstr {
 sub parse_args {
 
     my ( $templatefile, $logofile, $objectlevel, $split, $outdir, $force,
-         $filterstr, $idstr, $idfile, $skip_unpriced, $want_help );
+         $filterstr, $includestr, $idstr, $idfile, $skip_unpriced, $want_help );
 
     GetOptions(
         "t|template=s"      => \$templatefile,
@@ -65,6 +65,7 @@ sub parse_args {
         "d|output-dir=s"    => \$outdir,
         "f|force-overwrite" => \$force,
         "filters=s"         => \$filterstr,
+        "include=s"         => \$includestr,
         "cask-ids=s"        => \$idstr,
         "cask-ids-from=s"   => \$idfile,
         "skip-unpriced"     => \$skip_unpriced,
@@ -97,6 +98,11 @@ sub parse_args {
         $filters = [ map { [ split /=/, $_ ] } split /,/, $filterstr ];
     }
 
+    my $include_filters = [];
+    if ( $includestr ) {
+        $include_filters = [ map { [ split /=/, $_ ] } split /,/, $includestr ];
+    }
+
     my $cask_ids = [];
     if ( $idfile ) {
         open( my $idfh, '<', $idfile ) or die("Unable to open ID file: $!\n");
@@ -110,7 +116,7 @@ sub parse_args {
     }
 
     return( $templatefile, $logofile, $config, $objectlevel, $outdir,
-            $split, $force, $filters, $cask_ids, $skip_unpriced );
+            $split, $force, $filters, $include_filters, $cask_ids, $skip_unpriced );
 }
 
 ########
@@ -118,7 +124,7 @@ sub parse_args {
 ########
 
 my ( $templatefile, $logofile, $config, $objectlevel,
-     $outdir, $split, $force, $filters, $cask_ids, $skip_unpriced ) = parse_args();
+     $outdir, $split, $force, $filters, $include_filters, $cask_ids, $skip_unpriced ) = parse_args();
 
 my $schema = BeerFestDB::ORM->connect( @{ $config->{'Model::DB'}{'connect_info'} } );
 
@@ -131,6 +137,7 @@ my $dumper = BeerFestDB::Dumper::Template->new(
     output_dir    => $outdir,
     overwrite     => $force,
     filters       => $filters,
+    include_filters => $include_filters,
     cask_ids      => $cask_ids,
     skip_unpriced => $skip_unpriced,
 );
@@ -200,6 +207,18 @@ Beware of spaces in the filter string; all spaces are interpreted
 literally and will not be stripped from the applied filters. The
 filter names are defined by the code in BeerFestDB::Dumper::Template;
 please see that module's documentation for details.
+
+=item --include
+
+An optional set of filters defining objects to be included in the
+dumped data, using the same key=value syntax as C<--filters>:
+
+ --include 'category=ale,category=cider'
+
+When C<--include> is specified, only items matching at least one
+include filter are output.  If an item matches both an include filter
+and an exclude filter (C<--filters>), the include filter takes
+priority and the item is kept.
 
 =item --cask-ids
 


### PR DESCRIPTION
Possible script argument redesign which closes #31 (Adds `--include` argument; whitelist has higher priority than `--filter` blacklist). Backward compatible at the moment.