### PR TITLE
ProductCharacteristic handling

### DIFF
--- a/db/create_tables.sql
+++ b/db/create_tables.sql
@@ -983,7 +983,7 @@ CREATE TABLE `product_characteristic` (
   `product_id` int(6) NOT NULL,
   `product_characteristic_type_id` int(6) NOT NULL,
   `value` varchar(32) NOT NULL,
-  PRIMARY KEY (`product_id`),
+  PRIMARY KEY (`product_id`,`product_characteristic_type_id`),
   KEY `Rel_29` (`product_characteristic_type_id`),
   CONSTRAINT `product_characteristic_ibfk_1` FOREIGN KEY (`product_characteristic_type_id`) REFERENCES `product_characteristic_type` (`product_characteristic_type_id`) ON UPDATE NO ACTION,
   CONSTRAINT `product_characteristic_ibfk_2` FOREIGN KEY (`product_id`) REFERENCES `product` (`product_id`) ON UPDATE NO ACTION

--- a/db/initialise_vocabs.sql
+++ b/db/initialise_vocabs.sql
@@ -11,7 +11,7 @@ INSERT INTO `country` (`country_id`, `country_code_iso2`, `country_code_iso3`, `
 INSERT INTO `product_category` (`product_category_id`, `description`) VALUES (1,'beer'),(3,'cider'),(6,'cyser'),(2,'foreign beer'),(7,'mead'),(5,'perry'),(4,'wine');
 INSERT INTO `product_style` (`product_style_id`, `product_category_id`, `description`) VALUES (8,1,'Barley Wine'),(2,1,'Bitter'),(3,1,'Golden Ale'),(5,1,'IPA'),(11,1,'Light Bitter'),(1,1,'Mild'),(9,1,'Old Ale'),(4,1,'Pale Ale'),(6,1,'Porter'),(10,1,'Scottish Beer'),(7,1,'Stout'),(13,3,'dry'),(15,3,'medium'),(14,3,'medium dry'),(17,3,'medium sweet'),(16,3,'sweet'),(12,3,'very dry'),(18,3,'very sweet');
 INSERT INTO `product_allergen_type` (`product_allergen_type_id`, `description`) VALUES (1,'gluten'),(2,'peanuts'),(3,'sulphites'),(4,'celery'),(5,'nuts'),(6,'mustard'),(7,'fish'),(8,'milk'),(9,'crustaceans'),(10,'soybeans'),(11,'sesame'),(12,'lupins'),(13,'molluscs'),(14,'eggs');
-INSERT INTO `product_characteristic_type` (`product_characteristic_type_id`, `product_category_id`, `description`) VALUES (1,1,'colour'),(2,1,'clarity');
+INSERT INTO `product_characteristic_type` (`product_characteristic_type_id`, `product_category_id`, `description`) VALUES (1,1,'colour'),(2,1,'clarity'),(3,1,'finings status');
 INSERT INTO `role` (`role_id`, `rolename`) VALUES (1,'admin'),(2,'user'),(3,'manager');
 INSERT INTO `sale_volume` (`sale_volume_id`,`container_measure_id`,`description`,`volume`) VALUES (1,3,'pint',1.0),(2,5,'500ml bottle',1.0),(3,6,'175ml glass',1.0);
 INSERT INTO `telephone_type` (`telephone_type_id`, `description`) VALUES (2,'fax'),(1,'landline'),(3,'mobile');

--- a/db/initialise_vocabs.sql
+++ b/db/initialise_vocabs.sql
@@ -11,6 +11,7 @@ INSERT INTO `country` (`country_id`, `country_code_iso2`, `country_code_iso3`, `
 INSERT INTO `product_category` (`product_category_id`, `description`) VALUES (1,'beer'),(3,'cider'),(6,'cyser'),(2,'foreign beer'),(7,'mead'),(5,'perry'),(4,'wine');
 INSERT INTO `product_style` (`product_style_id`, `product_category_id`, `description`) VALUES (8,1,'Barley Wine'),(2,1,'Bitter'),(3,1,'Golden Ale'),(5,1,'IPA'),(11,1,'Light Bitter'),(1,1,'Mild'),(9,1,'Old Ale'),(4,1,'Pale Ale'),(6,1,'Porter'),(10,1,'Scottish Beer'),(7,1,'Stout'),(13,3,'dry'),(15,3,'medium'),(14,3,'medium dry'),(17,3,'medium sweet'),(16,3,'sweet'),(12,3,'very dry'),(18,3,'very sweet');
 INSERT INTO `product_allergen_type` (`product_allergen_type_id`, `description`) VALUES (1,'gluten'),(2,'peanuts'),(3,'sulphites'),(4,'celery'),(5,'nuts'),(6,'mustard'),(7,'fish'),(8,'milk'),(9,'crustaceans'),(10,'soybeans'),(11,'sesame'),(12,'lupins'),(13,'molluscs'),(14,'eggs');
+INSERT INTO `product_characteristic_type` (`product_characteristic_type_id`, `product_category_id`, `description`) VALUES (1,1,'colour'),(2,1,'clarity');
 INSERT INTO `role` (`role_id`, `rolename`) VALUES (1,'admin'),(2,'user'),(3,'manager');
 INSERT INTO `sale_volume` (`sale_volume_id`,`container_measure_id`,`description`,`volume`) VALUES (1,3,'pint',1.0),(2,5,'500ml bottle',1.0),(3,6,'175ml glass',1.0);
 INSERT INTO `telephone_type` (`telephone_type_id`, `description`) VALUES (2,'fax'),(1,'landline'),(3,'mobile');

--- a/db/migrations/20260507_fix_product_characteristic_pk.sql
+++ b/db/migrations/20260507_fix_product_characteristic_pk.sql
@@ -1,0 +1,25 @@
+-- Migration: Fix product_characteristic primary key
+-- Date: 2026-05-07
+
+-- Change PRIMARY KEY on `product_characteristic` from single-column (product_id)
+-- to composite (product_id, product_characteristic_type_id).  The old single-column
+-- PK incorrectly restricted each product to at most one characteristic.
+--
+-- The check tests whether `product_characteristic_type_id` is NOT already part of
+-- the PRIMARY KEY; if it is absent we drop and recreate the key.
+
+SET @pk_needs_fix := (
+  SELECT COUNT(*)
+  FROM information_schema.KEY_COLUMN_USAGE
+  WHERE TABLE_SCHEMA     = DATABASE()
+    AND TABLE_NAME       = 'product_characteristic'
+    AND CONSTRAINT_NAME  = 'PRIMARY'
+    AND COLUMN_NAME      = 'product_characteristic_type_id'
+);
+SET @sql := IF(@pk_needs_fix = 0,
+  'ALTER TABLE `product_characteristic` DROP PRIMARY KEY, ADD PRIMARY KEY (`product_id`, `product_characteristic_type_id`);',
+  'SELECT "product_characteristic primary key already updated";'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- End of migration

--- a/lib/BeerFestDB/Dumper/Template.pm
+++ b/lib/BeerFestDB/Dumper/Template.pm
@@ -144,6 +144,22 @@ sub allergen_hash {
     return \%allergen_data;
 }
 
+sub productcharacteristic_hash {
+
+    my ( $self, $product ) = @_;
+
+    # Return a hashref keyed by characteristic type; values are the
+    # characteristic value, as stored in the database.
+
+    my %char_data;
+
+    foreach my $char ( $product->search_related('product_characteristics') ) {
+        $char_data{ $char->product_characteristic_type_id->description() } = $char->value;
+    }
+
+    return \%char_data;
+}
+
 sub product_hash {
 
     my ( $self, $product, $prodhash ) = @_;
@@ -168,6 +184,7 @@ sub product_hash {
     $prodhash->{abv}      = $product->nominal_abv();
     $prodhash->{notes}    = $product->description();
     $prodhash->{allergens} = $self->allergen_hash( $product );
+    $prodhash->{characteristics} = $self->productcharacteristic_hash( $product );
     $prodhash->{is_vegan}  = $product->is_vegan();
     $prodhash->{_split_export_tag} = $tag;
 
@@ -832,7 +849,10 @@ A hashref of allergen records, keyed by the name of the allergens. All
 allergens stored in the database are represented. Values are
 1=present, 0=absent, undef=unknown.
 
-=back
+=item characteristics
+
+A hashref of product characteristics, keyed by the name of the characteristic
+and valued by the characteristic value as stored in the database.
 
 =item stillages
 

--- a/lib/BeerFestDB/Loader.pm
+++ b/lib/BeerFestDB/Loader.pm
@@ -142,6 +142,8 @@ Readonly my $DISTRIBUTOR_AWRS_URN      => 58;
 Readonly my $CASK_GRAVEYARD_LOCATION   => 59;
 Readonly my $PRODUCT_IS_VEGAN          => 60;
 Readonly my $ORDER_PRICE               => 61;
+Readonly my $PRODUCT_CHARACTERISTIC_TYPE    => 62;
+Readonly my $PRODUCT_CHARACTERISTIC_VALUE   => 63;
 
 ########
 # SUBS #
@@ -375,6 +377,32 @@ sub _load_data {
             },
             'Product')
         : undef;
+
+    my $pchar_type = $self->value_is_acceptable( $datahash->{$PRODUCT_CHARACTERISTIC_TYPE} )
+        ? $self->_load_column_value(
+            {
+                product_category_id => $category,
+                description         => $datahash->{$PRODUCT_CHARACTERISTIC_TYPE},
+            },
+            'ProductCharacteristicType')
+        : undef;
+
+    # ProductCharacteristic has a composite PK of (product_id,
+    # product_characteristic_type_id), so we cannot use _load_column_value
+    # (which skips PK columns when building the find_or_create search hash).
+    # Instead we use find_or_create directly with an explicit key hint.
+    my $pchar;
+    if ( $product && $pchar_type
+            && $self->value_is_acceptable( $datahash->{$PRODUCT_CHARACTERISTIC_VALUE} ) ) {
+        $pchar = $self->database->resultset('ProductCharacteristic')->find_or_create(
+            {
+                product_id                     => $product->product_id,
+                product_characteristic_type_id => $pchar_type->product_characteristic_type_id,
+                value                          => $datahash->{$PRODUCT_CHARACTERISTIC_VALUE},
+            },
+            { key => 'primary' },
+        );
+    }
 
     my $distributor
         = $self->value_is_acceptable( $datahash->{$DISTRIBUTOR_NAME} )
@@ -826,6 +854,8 @@ sub _coerce_headings {
         qr/product [_ -]* long [_ -]* description/ixms => $PRODUCT_LONG_DESCRIPTION,
         qr/product [_ -]* comment/ixms                 => $PRODUCT_COMMENT,
         qr/product [_ -]* abv/ixms                     => $PRODUCT_ABV,
+        qr/(?:product)? [_ -]* characteristic [_ -]* type/ixms  => $PRODUCT_CHARACTERISTIC_TYPE,
+        qr/(?:product)? [_ -]* characteristic [_ -]* value/ixms => $PRODUCT_CHARACTERISTIC_VALUE,
         qr/gyle [_ -]* brewery? [_ -]* number/ixms     => $GYLE_BREWERY_NUMBER,
         qr/gyle [_ -]* abv/ixms                        => $GYLE_ABV,
         qr/product [_ -]* sale [_ -]* price/ixms       => $GYLE_PINT_PRICE,

--- a/lib/BeerFestDB/ORM/ProductCharacteristic.pm
+++ b/lib/BeerFestDB/ORM/ProductCharacteristic.pm
@@ -58,11 +58,13 @@ __PACKAGE__->add_columns(
 
 =item * L</product_id>
 
+=item * L</product_characteristic_type_id>
+
 =back
 
 =cut
 
-__PACKAGE__->set_primary_key("product_id");
+__PACKAGE__->set_primary_key("product_id", "product_characteristic_type_id");
 
 =head1 RELATIONS
 

--- a/lib/BeerFestDB/Web/Controller.pm
+++ b/lib/BeerFestDB/Web/Controller.pm
@@ -190,14 +190,15 @@ sub _get_product_category : Private {
     # FIXME note that this may be rather too heavy on DB queries,
     # especially for large lists of updates.
     my %catmap = (
-        'Product'         => sub { $_[0]->product_category_id() },
-        'FestivalProduct' => sub { $self->_get_product_category( $c, $_[0]->product_id ) },
-        'Gyle'            => sub { $self->_get_product_category( $c, $_[0]->festival_product_id ) },
-        'Cask'            => sub { $self->_get_product_category( $c, $_[0]->gyle_id ) },
-        'CaskMeasurement' => sub { $self->_get_product_category( $c, $_[0]->cask_id ) },
-        'ProductOrder'    => sub { $self->_get_product_category( $c, $_[0]->product_id ) },
-        'CaskManagement'  => sub { $self->_get_product_category( $c, $_[0]->casks->first() ||
-                                                                     $_[0]->product_order_id, 1 ) },
+        'Product'               => sub { $_[0]->product_category_id() },
+        'ProductCharacteristic' => sub { $self->_get_product_category( $c, $_[0]->product_id ) },
+        'FestivalProduct'       => sub { $self->_get_product_category( $c, $_[0]->product_id ) },
+        'Gyle'                  => sub { $self->_get_product_category( $c, $_[0]->festival_product_id ) },
+        'Cask'                  => sub { $self->_get_product_category( $c, $_[0]->gyle_id ) },
+        'CaskMeasurement'       => sub { $self->_get_product_category( $c, $_[0]->cask_id ) },
+        'ProductOrder'          => sub { $self->_get_product_category( $c, $_[0]->product_id ) },
+        'CaskManagement'        => sub { $self->_get_product_category( $c, $_[0]->casks->first() ||
+                                                                           $_[0]->product_order_id, 1 ) },
     );
 
     if ( my $fun = $catmap{ $classname } ) {
@@ -224,7 +225,7 @@ sub _confirm_category_authorisation : Private {
     return if $c->check_any_user_role('admin');
 
     # Make sure this list matches the keys of %catmap, above.
-    if ( first { $_ eq $classname } qw( Product FestivalProduct Gyle
+    if ( first { $_ eq $classname } qw( Product ProductCharacteristic FestivalProduct Gyle
                                         Cask ProductOrder CaskManagement
                                         CaskMeasurement  ) ) {
 

--- a/lib/BeerFestDB/Web/Controller/Product.pm
+++ b/lib/BeerFestDB/Web/Controller/Product.pm
@@ -312,6 +312,16 @@ sub build_database_object : Private {
     my $allergens_present = delete $rec->{'allergens_present'} || '';
     my $allergens_absent  = delete $rec->{'allergens_absent'} || '';
 
+    # Detect a category change before the update is applied.
+    my $old_category_id;
+    if ( defined $rec->{product_id} ) {
+        my $existing = $c->model('DB::Product')->find({ product_id => $rec->{product_id} });
+        if ( $existing && defined $rec->{product_category_id}
+                       && $existing->product_category_id != $rec->{product_category_id} ) {
+            $old_category_id = $existing->product_category_id;
+        }
+    }
+
     my $obj = $self->next::method( $rec, $c, @other );
 
     # Check that all the wanted allergens are set appropriately.
@@ -341,9 +351,76 @@ sub build_database_object : Private {
                 $existing->delete;
             }
         }
+
+        # If the product category changed, reconcile any ProductCharacteristics
+        # whose type no longer belongs to the new category.
+        if ( defined $old_category_id ) {
+            $self->_reconcile_characteristics_after_category_change(
+                $c, $obj, $rec->{product_category_id} );
+        }
     }
 
     return $obj;
+}
+
+=head2 _reconcile_characteristics_after_category_change
+
+Called when a Product's product_category_id is changed. Iterates over
+all attached ProductCharacteristic rows; for each one whose
+ProductCharacteristicType belongs to the old category:
+
+=over 4
+
+=item * If a ProductCharacteristicType with the same description exists in
+the new category, updates the characteristic to use that type.
+
+=item * Otherwise, deletes the characteristic.
+
+=back
+
+=cut
+
+sub _reconcile_characteristics_after_category_change : Private {
+
+    my ( $self, $c, $obj, $new_category_id ) = @_;
+
+    my $pct_rs = $c->model('DB::ProductCharacteristicType');
+
+    foreach my $char ( $obj->product_characteristics ) {
+        my $type = $char->product_characteristic_type_id;
+        next if $type->get_column('product_category_id') == $new_category_id;
+
+        # Type belongs to the old category. Try to find a replacement
+        # in the new category with the same description.
+        my $replacement = $pct_rs->find({
+            product_category_id => $new_category_id,
+            description         => $type->description,
+        });
+
+        if ( $replacement ) {
+            # Check whether a characteristic for this product with the
+            # replacement type already exists (avoid PK collision).
+            my $existing = $c->model('DB::ProductCharacteristic')->find({
+                product_id                    => $obj->product_id,
+                product_characteristic_type_id => $replacement->product_characteristic_type_id,
+            });
+            if ( $existing ) {
+                # Replacement already exists; just remove the mismatched one.
+                $char->delete;
+            }
+            else {
+                $char->update({
+                    product_characteristic_type_id =>
+                        $replacement->product_characteristic_type_id,
+                });
+            }
+        }
+        else {
+            $char->delete;
+        }
+    }
+
+    return;
 }
 
 =head2 viewhash_from_model

--- a/lib/BeerFestDB/Web/Controller/ProductCharacteristic.pm
+++ b/lib/BeerFestDB/Web/Controller/ProductCharacteristic.pm
@@ -1,0 +1,145 @@
+#
+# This file is part of BeerFestDB, a beer festival product management
+# system.
+# 
+# Copyright (C) 2017 Tim F. Rayner
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# $Id$
+
+package BeerFestDB::Web::Controller::ProductCharacteristic;
+use Moose;
+use namespace::autoclean;
+
+BEGIN { extends 'BeerFestDB::Web::GenericGrid'; }
+
+=head1 NAME
+
+BeerFestDB::Web::Controller::ProductCharacteristic - Catalyst Controller
+
+=head1 DESCRIPTION
+
+Catalyst Controller.
+
+=head1 METHODS
+
+=cut
+
+sub BUILD {
+
+    my ( $self, $params ) = @_;
+
+    $self->model_view_map({
+        product_id                     => 'product_id',
+        product_characteristic_type_id => 'product_characteristic_type_id',
+        value                          => 'value',
+    });
+
+    $self->model_name('DB::ProductCharacteristic');
+}
+
+=head2 load_form
+
+=cut
+
+sub load_form : Local {
+
+    my ( $self, $c ) = @_;
+
+    my $rs = $c->model( $self->model_name() );
+
+    $self->form_json_and_detach( $c, $rs, 'product_characteristic_id' );
+}
+
+=head2 view
+
+=cut
+
+sub view : Local {
+
+    my ( $self, $c, $id ) = @_;
+
+    my $object = $c->model( $self->model_name() )->find($id);
+
+    unless ( $object ) {
+        $c->flash->{error} = "Error: ProductCharacteristic not found.";
+        $c->res->redirect( $c->uri_for('/default') );
+        $c->detach();        
+    }
+
+    $c->stash->{object} = $object;
+
+    return;
+}
+
+=head2 list
+
+=cut
+
+sub list : Local {
+
+    my ( $self, $c ) = @_;
+
+    if ( my $product_id = $c->req()->params()->{ product_id } ) {
+        $c->res->redirect( $c->uri_for('list_by_product', $product_id) );
+    } else {
+        $self->SUPER::list($c);
+    }
+}
+
+=head2 list_by_product
+
+=cut
+
+sub list_by_product : Local {
+
+    my ( $self, $c, $product_id ) = @_;
+
+    my $rs = $c->model( $self->model_name() )->search({ product_id => $product_id });
+
+    $self->generate_json_and_detach( $c, $rs );
+}
+
+=head2 build_database_object
+
+=cut
+
+sub build_database_object {
+
+    my ( $self, $rec, $c, @other ) = @_;
+
+    # Confirm that the ProductCharacteristicType is valid for the product's Category.
+    my $type     = $c->model("DB::ProductCharacteristicType")->find($rec->{product_characteristic_type_id});
+    my $product  = $c->model("DB::Product")->find($rec->{product_id});
+
+    if ( $type->product_category_id != $product->product_category_id ) {
+        $self->raise_exception($c, "Product characteristic type is not valid for the product's category.\n");
+    }
+
+    return $self->next::method( $rec, $c, @other );
+}
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2017-2026 by Tim F. Rayner
+
+This library is released under version 3 of the GNU General Public
+License (GPL).
+
+=cut
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/lib/BeerFestDB/Web/Controller/ProductCharacteristic.pm
+++ b/lib/BeerFestDB/Web/Controller/ProductCharacteristic.pm
@@ -124,11 +124,50 @@ sub build_database_object {
     my $type     = $c->model("DB::ProductCharacteristicType")->find($rec->{product_characteristic_type_id});
     my $product  = $c->model("DB::Product")->find($rec->{product_id});
 
-    if ( $type->product_category_id != $product->product_category_id ) {
+    $c->log->debug("build_database_object: product_characteristic_type_id = " .
+                    $rec->{product_characteristic_type_id} . ", product_id = " . $rec->{product_id});
+
+    if ( $type->product_category_id->id != $product->product_category_id->id ) {
+        $c->log->error("ProductCharacteristicType category " . $type->product_category_id->id . 
+                       " does not match Product category " . $product->product_category_id->id);
         $self->raise_exception($c, "Product characteristic type is not valid for the product's category.\n");
     }
 
     return $self->next::method( $rec, $c, @other );
+}
+
+=head2 delete_from_resultset
+
+Overrides the base implementation to support the composite primary key
+(product_id, product_characteristic_type_id).
+
+=cut
+
+sub delete_from_resultset : Private {
+
+    my ( $self, $c, $rs ) = @_;
+
+    my $data = $self->decode_json_changes( $c );
+
+    eval {
+        $rs->result_source()->schema()->txn_do(
+            sub {
+                foreach my $id ( @{ $data } ) {
+                    my $rec = $rs->find({
+                        product_id                     => $id->{product_id},
+                        product_characteristic_type_id => $id->{product_characteristic_type_id},
+                    });
+                    $self->delete_database_object( $c, $rec ) if $rec;
+                }
+            }
+        );
+    };
+    if ( $@ or scalar @{ $c->error } ) {
+        $self->detach_with_txn_failure( $c );
+    };
+
+    $c->stash->{ 'success' } = JSON->false();
+    $c->forward( 'View::JSON' );
 }
 
 =head1 COPYRIGHT AND LICENSE

--- a/root/src/product/view.tt2
+++ b/root/src/product/view.tt2
@@ -7,6 +7,12 @@
    var url_festival_product_list = '[% c.uri_for( "/festivalproduct/list_by_product/$object.id" ) %]';
    var url_company_view          = '[% c.uri_for( "/company/view/$object.company_id.id" ) %]';
 
+   [%# Product Characteristic are special cases %]
+   var url_product_characteristic_type_list = '[% c.uri_for( "/productcharacteristictype/list_by_category/" _ object.product_category_id.id ) %]';
+   var url_product_characteristic_list = '[% c.uri_for( "/productcharacteristic/list_by_product/" _ object.id ) %]';
+   var url_product_characteristic_delete = '[% c.uri_for( "/productcharacteristic/delete" ) %]';
+   var url_product_characteristic_submit = '[% c.uri_for( "/productcharacteristic/submit" ) %]';
+
    var product_id  = '[% object.id %]';
    var productname = '[% object.name | xml %]';
 </script>

--- a/root/src/product/view.tt2
+++ b/root/src/product/view.tt2
@@ -9,6 +9,7 @@
 
    [%# Product Characteristic are special cases %]
    var url_product_characteristic_type_list = '[% c.uri_for( "/productcharacteristictype/list_by_category/" _ object.product_category_id.id ) %]';
+   var url_product_characteristic_type_list_base = '[% c.uri_for( "/productcharacteristictype/list_by_category" ) %]';
    var url_product_characteristic_list = '[% c.uri_for( "/productcharacteristic/list_by_product/" _ object.id ) %]';
    var url_product_characteristic_delete = '[% c.uri_for( "/productcharacteristic/delete" ) %]';
    var url_product_characteristic_submit = '[% c.uri_for( "/productcharacteristic/submit" ) %]';

--- a/root/static/js/classes.js
+++ b/root/static/js/classes.js
@@ -198,6 +198,9 @@ RemoveButton = Ext.extend(Ext.Button, {
             {
                 handler:        function() {
                     this.grid.stopEditing();
+                    // Capture selections NOW, before the modal dialog causes
+                    // the grid to lose focus and deselect rows (ExtJS 3 bug).
+                    var dirty = this.sm.getSelections();
                     Ext.Msg.show({
                         title:    'Delete',
                         msg:      'Really delete the selected rows?',
@@ -206,9 +209,16 @@ RemoveButton = Ext.extend(Ext.Button, {
                         fn:       function(btn, text){
                             if (btn == 'yes'){
                                 var changes = new Array();
-                                var dirty   = this.sm.getSelections();
                                 for ( var i = 0 ; i < dirty.length ; i++ ) {
-                                    var id = dirty[i].get( this.idField );
+                                    var id;
+                                    if ( Ext.isArray(this.idField) ) {
+                                        id = {};
+                                        for ( var j = 0 ; j < this.idField.length ; j++ ) {
+                                            id[ this.idField[j] ] = dirty[i].get( this.idField[j] );
+                                        }
+                                    } else {
+                                        id = dirty[i].get( this.idField );
+                                    }
                                     changes.push( id );
                                 }
                                 deleteProducts( changes,

--- a/root/static/js/classes.js
+++ b/root/static/js/classes.js
@@ -249,6 +249,7 @@ MyEditorGrid = Ext.extend(Ext.grid.EditorGridPanel, {
     stripeRows:         true,
     trackMouseOver:     true,
     loadMask:           true, // seems not to work in extjs 3.4
+    clicksToEdit:       1,    // single click activates cell editors (enables smooth tab navigation)
     comboStores:        [],
     viewConfig: new Ext.grid.GridView({
         autoFill: true,
@@ -358,6 +359,26 @@ MyEditorGrid = Ext.extend(Ext.grid.EditorGridPanel, {
         });
 
         MyEditorGrid.superclass.initComponent.apply(this, arguments);
+    },
+
+    // Intercept Tab at document capture phase so Firefox cannot move browser
+    // focus away, then delegate to the selection model's onEditorKey — exactly
+    // mirroring what the editor's 'specialkey' listener does internally.
+    afterRender: function() {
+        MyEditorGrid.superclass.afterRender.apply(this, arguments);
+        var grid = this;
+        document.addEventListener('keydown', function(e) {
+            if (e.key !== 'Tab' && e.keyCode !== 9) { return; }
+            if (!grid.activeEditor) { return; }
+            // Prevent Firefox from moving browser focus away from the editor.
+            e.preventDefault();
+            // Stop propagation so the Tab keydown does not also reach the
+            // editor field's own 'specialkey' listener, which would fire
+            // onEditorKey a second time on the newly opened editor.
+            e.stopPropagation();
+            var extEvt = Ext.EventObject.setEvent(e);
+            grid.getSelectionModel().onEditorKey(grid.activeEditor.field, extEvt);
+        }, true /* useCapture */);
     },
 
     onRender: function() {

--- a/root/static/js/grids/product_view.js
+++ b/root/static/js/grids/product_view.js
@@ -274,6 +274,65 @@ Ext.onReady(function(){
         loadUrl:     url_product_load_form,
         idParams:    { product_id: product_id },
         waitMsg:     'Loading Product details...',
+
+        // Tracks the new category ID when the user changes category, so afterSave
+        // can reload the characteristic type store with the correct URL.
+        _pendingCategoryId: null,
+
+        // Warn the user if they are changing the product category, since this
+        // may cause product characteristics to be deleted or remapped.
+        beforeSave: function(doSave) {
+            var panel = this;
+            var catField = panel.getForm().findField('product_category_id');
+            if (catField && catField.isDirty()) {
+                // Capture the new category ID now, before the form reloads.
+                panel._pendingCategoryId = catField.getValue();
+                var oldRec = category_store.getById(catField.originalValue);
+                var newRec = category_store.getById(panel._pendingCategoryId);
+                var oldName = oldRec ? oldRec.get('description') : catField.originalValue;
+                var newName = newRec ? newRec.get('description') : panel._pendingCategoryId;
+                Ext.Msg.show({
+                    title:   'Changing Product Category',
+                    msg:     'You are changing the category from <b>' + oldName + '</b> to <b>' + newName + '</b>.<br><br>'
+                           + 'Any product characteristics whose type does not exist in the new category '
+                           + 'will be <b>deleted or remapped</b>. Continue?',
+                    buttons: Ext.Msg.YESNO,
+                    icon:    Ext.MessageBox.WARNING,
+                    fn:      function(btn) {
+                        if (btn === 'yes') { doSave(); }
+                        else { panel._pendingCategoryId = null; }
+                    },
+                });
+            } else {
+                panel._pendingCategoryId = null;
+                doSave();
+            }
+        },
+
+        // After saving, reload the form (clears dirty state) and, if the
+        // category changed, update the characteristic type store URL and
+        // reload both it and the characteristic data store.
+        afterSave: function() {
+            var panel = prodForm;
+            var newCatId = panel._pendingCategoryId;
+            panel._pendingCategoryId = null;
+
+            if (newCatId) {
+                var newUrl = url_product_characteristic_type_list_base + '/' + newCatId;
+                product_characteristic_type_store.proxy.conn.url = newUrl;
+                product_characteristic_type_store.reload({
+                    callback: function() {
+                        product_characteristic_store.reload();
+                    }
+                });
+            }
+
+            panel.getForm().load({
+                url:     panel.loadUrl,
+                params:  panel.idParams,
+                waitMsg: panel.waitMsg,
+            });
+        },
     });
 
     /* Product Characteristic grid */

--- a/root/static/js/grids/product_view.js
+++ b/root/static/js/grids/product_view.js
@@ -291,6 +291,7 @@ Ext.onReady(function(){
             },
             store:              product_characteristic_store,
             comboStores:         [ product_characteristic_type_store ],
+            reloadableStores:    [ product_characteristic_type_store ], // fixes refresh view bug after save
             contentCols: [
                 { id:         'product_characteristic_type_id',
                   header:     'Characteristic Type',

--- a/root/static/js/grids/product_view.js
+++ b/root/static/js/grids/product_view.js
@@ -99,6 +99,50 @@ Ext.onReady(function(){
         },
     });
 
+    /* Product Characteristic drop-down */
+    var ProductCharacteristicType = Ext.data.Record.create([
+        { name: 'product_characteristic_type_id', type: 'int' },
+        { name: 'product_category_id',            type: 'int' },
+        { name: 'description',                    type: 'string' },
+    ]);
+
+    var product_characteristic_type_store = new Ext.data.JsonStore({
+        url:        url_product_characteristic_type_list,
+        root:       'objects',
+        fields:     ProductCharacteristicType,
+        idProperty: 'product_characteristic_type_id',
+        sortInfo:   {
+            field:     'description',
+            direction: 'ASC',
+        },
+    });
+
+    var product_characteristic_type_combo = new Ext.form.ComboBox({
+        typeAhead:      true,
+        triggerAction:  'all',
+        mode:           'local',
+        store:          product_characteristic_type_store,
+        valueField:     'product_characteristic_type_id',
+        displayField:   'description',
+        lazyRender:     true,
+        noSelection:    emptySelect,
+        forceSelection: true,
+        xtype:          'mycombo',
+    });
+
+    var product_characteristic_store = new Ext.data.JsonStore({
+        url:        url_product_characteristic_list,
+        root:       'objects',
+        fields:     [{ name: 'product_id',                type: 'int' },
+                     { name: 'product_characteristic_type_id', type: 'int' },
+                     { name: 'value',                     type: 'string' }],
+        idProperty: 'product_characteristic_type_id',
+        sortInfo:   {
+            field:     'product_characteristic_type_id',
+            direction: 'ASC',
+        },
+    });
+
     function updateStyleList(query) { // Listener function to update style dropdown.
         var currentRowId = prodForm.getForm().findField('product_category_id').getValue();
         this.store.reload( { params: { product_category_id: currentRowId }, add: true } );
@@ -232,6 +276,42 @@ Ext.onReady(function(){
         waitMsg:     'Loading Product details...',
     });
 
+    /* Product Characteristic grid */
+    var charGrid = new MyEditorGrid(
+        {
+            objLabel:           'Product Characteristic',
+            idField:            ['product_id', 'product_characteristic_type_id'],
+            autoExpandColumn:   'value',
+            deleteUrl:          url_product_characteristic_delete,
+            submitUrl:          url_product_characteristic_submit,
+            recordChanges:      function (record) {
+                var fields = record.getChanges();
+                fields.product_id = product_id;
+                return(fields);
+            },
+            store:              product_characteristic_store,
+            comboStores:         [ product_characteristic_type_store ],
+            contentCols: [
+                { id:         'product_characteristic_type_id',
+                  header:     'Characteristic Type',
+                  dataIndex:  'product_characteristic_type_id',
+                  width:      130,
+                  renderer:   MyComboRenderer(product_characteristic_type_combo),
+                  editor:     product_characteristic_type_combo,
+                  },
+                { id:         'value',
+                  header:     'Value',
+                  dataIndex:  'value',
+                  width:      150,
+                  editor:     new Ext.form.TextField({
+                      allowBlank:     true,
+                  })},
+            ],
+            // Dead link - we have a no target view for product characteristics, and the link is not worth the effort of creating one.
+            viewLink: function (grid, record, action, row, col) {},
+        }
+    );
+
     /* Festival Product grid */
     var fpGrid = new MyEditorGrid(
         {
@@ -277,12 +357,12 @@ Ext.onReady(function(){
             { title: 'Product Information',
               layout: 'anchor',
               items:  prodForm, },
+            { title: 'Characteristics',
+              layout: 'fit',
+              items:  charGrid, },
             { title: 'Festivals',
               layout: 'fit',
               items:  fpGrid, },
-//            { title: 'Characteristics',
-//              layout: 'fit',
-//              items:  charGrid, },
         ],
     });
 

--- a/t/loader.t
+++ b/t/loader.t
@@ -162,9 +162,18 @@ is( $db->resultset('ProductCharacteristic')->count(), 1,
     'Exactly one ProductCharacteristic created for a valid row' );
 
 my $pchar_rec = $db->resultset('ProductCharacteristic')->first();
-is( $pchar_rec->value,                                 'High', 'ProductCharacteristic has correct value' );
-is( $pchar_rec->get_column('product_id'),              1,      'ProductCharacteristic linked to correct product' );
-is( $pchar_rec->get_column('product_characteristic_type_id'), 1,
+is( $pchar_rec->value,                    'High', 'ProductCharacteristic has correct value' );
+is( $pchar_rec->get_column('product_id'), 1,      'ProductCharacteristic linked to correct product' );
+
+my $loaded_type = $db->resultset('ProductCharacteristicType')->find({
+    description         => 'TestCharacteristic',
+    product_category_id => $db->resultset('ProductCategory')
+                               ->find({ description => 'foreign beer' })
+                               ->product_category_id,
+});
+ok( defined $loaded_type, 'ProductCharacteristicType TestCharacteristic/foreign beer exists after load' );
+is( $pchar_rec->get_column('product_characteristic_type_id'),
+    $loaded_type->product_characteristic_type_id,
     'ProductCharacteristic linked to correct type' );
 
 # 4. Loading the same row again is idempotent (find_or_create).

--- a/t/loader.t
+++ b/t/loader.t
@@ -75,4 +75,123 @@ lives_ok { $loader2->load() } 'load() completes without dying for a simple produ
 my @companies = $load_db->resultset('Company')->search({ name => 'Acme Test Brewery' })->all();
 is( scalar @companies, 1, 'Loader created the expected Company record' );
 
+# -----------------------------------------------------------------------
+# _coerce_headings — characteristic column heading variants
+# -----------------------------------------------------------------------
+
+my $canon = $loader->_coerce_headings([ 'characteristic_type', 'characteristic_value' ]);
+ok( $canon->[0] != 0, '_coerce_headings: "characteristic_type" is recognised (not UNKNOWN_COLUMN)' );
+ok( $canon->[1] != 0, '_coerce_headings: "characteristic_value" is recognised (not UNKNOWN_COLUMN)' );
+isnt( $canon->[0], $canon->[1], '_coerce_headings: type and value map to distinct constants' );
+
+my $prefixed = $loader->_coerce_headings([ 'product_characteristic_type', 'product_characteristic_value' ]);
+is( $prefixed->[0], $canon->[0],
+    '_coerce_headings: "product_characteristic_type" maps to same constant as "characteristic_type"' );
+is( $prefixed->[1], $canon->[1],
+    '_coerce_headings: "product_characteristic_value" maps to same constant as "characteristic_value"' );
+
+my $spaced = $loader->_coerce_headings([ 'characteristic type', 'characteristic-value' ]);
+is( $spaced->[0], $canon->[0],
+    '_coerce_headings: space-separated "characteristic type" maps correctly' );
+is( $spaced->[1], $canon->[1],
+    '_coerce_headings: hyphen-separated "characteristic-value" maps correctly' );
+
+# -----------------------------------------------------------------------
+# load() — ProductCharacteristic loading
+# -----------------------------------------------------------------------
+
+# Helper: build a TSV tempfile from headers + rows.
+sub _make_tsv {
+    my ( @rows ) = @_;
+    my ( $fh, $file ) = tempfile( SUFFIX => '.tsv', UNLINK => 1 );
+    print $fh join( "\t", @$_ ) . "\n" for @rows;
+    close $fh;
+    return $file;
+}
+
+# The shared test DB (t/testing.db) has:
+#   ProductCharacteristicType id=1, category='foreign beer', description='TestCharacteristic'
+#   Product id=1, name='TestBeer', company='TestBrewer', category='foreign beer'
+
+my @char_headers = qw( brewery_name product_name product_category
+                        characteristic_type characteristic_value );
+
+# 1. Both columns blank — no ProductCharacteristic created.
+my $pc_blank_both = _make_tsv(
+    \@char_headers,
+    [ 'TestBrewer', 'TestBeer', 'foreign beer', '', '' ],
+);
+my $loader_blank_both = BeerFestDB::Loader->new(
+    database  => $db,
+    csv_file  => $pc_blank_both,
+    protected => [],
+);
+lives_ok { $loader_blank_both->load() }
+    'characteristic load: blank type+value does not die';
+is( $db->resultset('ProductCharacteristic')->count(), 0,
+    'No ProductCharacteristic created when both columns are blank' );
+
+# 2. Value blank, type present — no ProductCharacteristic created.
+my $pc_blank_val = _make_tsv(
+    \@char_headers,
+    [ 'TestBrewer', 'TestBeer', 'foreign beer', 'TestCharacteristic', '' ],
+);
+my $loader_blank_val = BeerFestDB::Loader->new(
+    database  => $db,
+    csv_file  => $pc_blank_val,
+    protected => [],
+);
+lives_ok { $loader_blank_val->load() }
+    'characteristic load: blank value (type present) does not die';
+is( $db->resultset('ProductCharacteristic')->count(), 0,
+    'No ProductCharacteristic created when characteristic_value is blank' );
+
+# 3. Valid type + value — ProductCharacteristic created with correct fields.
+my $pc_valid = _make_tsv(
+    \@char_headers,
+    [ 'TestBrewer', 'TestBeer', 'foreign beer', 'TestCharacteristic', 'High' ],
+);
+my $loader_valid = BeerFestDB::Loader->new(
+    database  => $db,
+    csv_file  => $pc_valid,
+    protected => [],
+);
+lives_ok { $loader_valid->load() }
+    'characteristic load: valid type+value does not die';
+is( $db->resultset('ProductCharacteristic')->count(), 1,
+    'Exactly one ProductCharacteristic created for a valid row' );
+
+my $pchar_rec = $db->resultset('ProductCharacteristic')->first();
+is( $pchar_rec->value,                                 'High', 'ProductCharacteristic has correct value' );
+is( $pchar_rec->get_column('product_id'),              1,      'ProductCharacteristic linked to correct product' );
+is( $pchar_rec->get_column('product_characteristic_type_id'), 1,
+    'ProductCharacteristic linked to correct type' );
+
+# 4. Loading the same row again is idempotent (find_or_create).
+my $loader_again = BeerFestDB::Loader->new(
+    database  => $db,
+    csv_file  => $pc_valid,
+    protected => [],
+);
+lives_ok { $loader_again->load() }
+    'characteristic load: re-loading the same row does not die';
+is( $db->resultset('ProductCharacteristic')->count(), 1,
+    'Re-loading the same row does not create a duplicate' );
+
+# 5. The "product_characteristic_type/value" header prefix variants are recognised.
+my $pc_prefixed = _make_tsv(
+    [ 'brewery_name', 'product_name', 'product_category',
+      'product_characteristic_type', 'product_characteristic_value' ],
+    [ 'TestBrewer', 'TestBeer', 'foreign beer', 'TestCharacteristic', 'High' ],
+);
+my $loader_prefixed = BeerFestDB::Loader->new(
+    database  => $db,
+    csv_file  => $pc_prefixed,
+    protected => [],
+);
+lives_ok { $loader_prefixed->load() }
+    'characteristic load: "product_characteristic_type/value" header variants do not die';
+is( $db->resultset('ProductCharacteristic')->count(), 1,
+    'No duplicate created when loading with product_characteristic_type/value headers' );
+
 done_testing();

--- a/util/templates/cask_end_template.tt2
+++ b/util/templates/cask_end_template.tt2
@@ -80,6 +80,21 @@ Note that cask end signs created using product_order dump class info may be inac
 
 \end{textblock}
 
+[%-# Product characteristics -%]
+
+\fontsize{24}{30}
+\selectfont
+\begin{textblock}{0.15}(0.80,0.14)
+
+[% SET chars = cask.characteristics %]
+[% IF chars.colour.defined && chars.colour != '' %] Colour: \textbf{[% chars.colour %]} [% END %] \\
+\\
+[% IF chars.clarity.defined && chars.clarity != '' %] Clarity: \textbf{[% chars.clarity %]} [% END %] \\
+
+\end{textblock}
+
+[%-# Brewery and product name -%]
+
   \fontsize{48}{60}
   \selectfont
 
@@ -96,8 +111,6 @@ Note that cask end signs created using product_order dump class info may be inac
       [% product_font_size = 86 %]
     [% END %]
   [% END %]
-
-[%-# Brewery and product name -%]
 
   \begin{textblock}{0.6}[0.5,0](0.5,0.05)
   \begin{center}

--- a/util/templates/cask_end_template.tt2
+++ b/util/templates/cask_end_template.tt2
@@ -84,13 +84,10 @@ Note that cask end signs created using product_order dump class info may be inac
 
 \fontsize{24}{30}
 \selectfont
-\begin{textblock}{0.15}(0.80,0.14)
-
+\begin{textblock}{0.15}(0.04,0.02)
 [% SET chars = cask.characteristics %]
-[% IF chars.colour.defined && chars.colour != '' %] Colour: \textbf{[% chars.colour %]} [% END %] \\
-\\
-[% IF chars.clarity.defined && chars.clarity != '' %] Clarity: \textbf{[% chars.clarity %]} [% END %] \\
-
+[% IF chars.colour.defined && chars.colour != '' %] {\fontsize{14}{16}\selectfont Colour:} \textbf{[% chars.colour | latexify %]} \\\\ [% END %]
+[% IF chars.clarity.defined && chars.clarity != '' %] {\fontsize{14}{16}\selectfont Clarity:} \textbf{[% chars.clarity | latexify | upper %]} \\ [% END %]
 \end{textblock}
 
 [%-# Brewery and product name -%]


### PR DESCRIPTION
This PR will add full support for ProductCharacteristic

- [x] Schema fixes for primary key on `product_characteristic` table
- [x] Add full web UI support for setting, changing, deleting ProductCharacteristic (including handling of changes in Product.product_category_id that would otherwise invalidate the characteristics relationship)
- [x] Loader support for product characteristics
- [x] Dumper::Template support for product characteristics
- [x] #115 Example of use for cask end signs (likely for `colour` to start with (#39))

Additional uses of characteristics can then be developed by adding new terms (`clarity`, `finings status`) and finding space for them in whichever set of outputs is desired (editing of templates).

Closes #39, #40, #41, #115