### PR TITLE
Various minor deployment bug fixes

### DIFF
--- a/beerfestdb_web_site.yml
+++ b/beerfestdb_web_site.yml
@@ -79,12 +79,12 @@ Plugin::OpenIDConnect:
     'dashboard':
        client_secret: 'my-secret'
        redirect_uris: 'http://localhost:8501/oauth2callback'
+       post_logout_redirect_uris: 'http://localhost:8501/oauth2callback'
   # Optional Redis store configuration for OpenID Connect session management. Likely
-  # to be required for FastCGI deployments. If not specified, sessions will be stored
-  # in memory (not recommended for production use).
-  store_class: 'Catalyst::Plugin::OpenIDConnect::Utils::Store::Redis' 
+  # Redis store for OpenID Connect session management - required for multi-worker
+  # FastCGI deployments so auth codes are shared across all worker processes.
+  store_class: 'Catalyst::Plugin::OpenIDConnect::Utils::Store::Redis'
   store_args:
-    redis:
-      server: 'localhost:6379'
-      namespace: 'oidc:beerfestdb:'
-      code_ttl: 600
+    server: 'redis:6379'
+    prefix: 'oidc:beerfestdb:'
+    code_ttl: 600

--- a/db/create_tables.sql
+++ b/db/create_tables.sql
@@ -842,7 +842,7 @@ CREATE TABLE `product` (
   `description` text,
   `long_description` text,
   `comment` text,
-  `is_vegan` tinyint(1) DEFAULT NULL, // nullable so we can record 'known unknowns' positively
+  `is_vegan` tinyint(1) DEFAULT NULL, -- nullable so we can record 'known unknowns' positively
   PRIMARY KEY (`product_id`),
   UNIQUE KEY `company_id` (`company_id`,`name`),
   KEY `IDX_pdc_pcid` (`product_category_id`),

--- a/lib/BeerFestDB/Web.pm
+++ b/lib/BeerFestDB/Web.pm
@@ -72,6 +72,7 @@ __PACKAGE__->config(
             sub => 'id',
             name => 'name',
             email => 'email',
+            preferred_username => 'username',
         },
         debug => 0, # Set to 1 for specific logging of OIDC plugin including setup.
     },

--- a/tool_dashboard/.dockerignore
+++ b/tool_dashboard/.dockerignore
@@ -1,0 +1,5 @@
+.venv*
+.venv
+.venv_dashboard
+.vscode
+.streamlit

--- a/tool_dashboard/CBF_tool_page.py
+++ b/tool_dashboard/CBF_tool_page.py
@@ -33,7 +33,8 @@ def _inactivity_check():
 
 _inactivity_check()
 
-st.markdown(f"Welcome {st.user.name}!")
+display_name = st.user.get("name") or st.user.get("preferred_username") or st.user.get("email") or "user"
+st.markdown(f"Welcome {display_name}!")
 
 if st.button("Log out"):
     st.logout()

--- a/tool_dashboard/requirements.txt
+++ b/tool_dashboard/requirements.txt
@@ -1,8 +1,9 @@
 pandas
-streamlit
+streamlit[auth]
 mysql-connector-python
 SQLAlchemy
 mysqlclient
 numpy
 PyYAML
 Authlib
+httpx


### PR DESCRIPTION
Mostly errors in files not used once a deployment has been created. The one exception is to the tools dashboard, allowing BeerFestDB users who don't actually have a `name` attribute set to be able to log in.