### PR TITLE
Wrap streamlit script and restart on healthcheck fail

### DIFF
--- a/lib/BeerFestDB/Dumper/Template.pm
+++ b/lib/BeerFestDB/Dumper/Template.pm
@@ -681,7 +681,7 @@ sub filter_to_latex {
     $text =~ s/ (?: ·  | \x{b7} ) /\\textperiodcentered /gxms;
     $text =~ s/ (?: ž | \x{17e} ) /\\v{z}/gxms;
     $text =~ s/ (?: Ā | \x{100} ) /\\={A}/gxms;
-    $text =~ s/ (?: ě | \x{11b} ) /\\v{A}/gxms;
+    $text =~ s/ (?: ě | \x{11b} ) /\\v{e}/gxms;
 
     return $text;
 }

--- a/lib/BeerFestDB/Web/PriceController.pm
+++ b/lib/BeerFestDB/Web/PriceController.pm
@@ -21,6 +21,7 @@
 
 package BeerFestDB::Web::PriceController;
 use Moose;
+use Scalar::Util qw/reftype/;
 use namespace::autoclean;
 
 BEGIN {extends 'BeerFestDB::Web::Controller'; }
@@ -87,7 +88,8 @@ sub decode_json_changes : Private {
 
     my $field = $self->price_field();
     foreach my $rec ( @{ $data } ) {
-        if ( exists $rec->{$field} ) {
+        # Note that $rec is just an integer if we're deleting records
+        if ( reftype($rec) eq 'HASH' && exists $rec->{$field} ) {
             my $currency = $self->_fetch_currency($rec, $c);
             $rec->{$field} = $self->parse_price(
                 $rec->{$field}, $currency

--- a/tool_dashboard/CBF_get_next_caskID.py
+++ b/tool_dashboard/CBF_get_next_caskID.py
@@ -5,6 +5,7 @@ import streamlit as st
 import yaml
 from pathlib import Path
 from bfdb_yaml import current_festival
+from datetime import datetime
 
 #%%
 conn = st.connection('cbf', type='sql')
@@ -31,6 +32,7 @@ conn.close()
 
 st.header(f'{festivalname}')
 st.write("Use the menu in the left sidebar to choose another festival")
+st.write("Time of last database query: " + datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
 
 ## fish the actual number out and assign to caskmax
 

--- a/tool_dashboard/Dockerfile
+++ b/tool_dashboard/Dockerfile
@@ -18,4 +18,4 @@ EXPOSE ${PORT}
 
 HEALTHCHECK CMD curl --fail http://localhost:${PORT}/_stcore/health
 
-ENTRYPOINT streamlit run CBF_tool_page.py --server.port=${PORT} --server.address=0.0.0.0
+ENTRYPOINT /bin/bash run_dashboard.sh --port=${PORT} --streamlit-path=streamlit

--- a/tool_dashboard/run_dashboard.sh
+++ b/tool_dashboard/run_dashboard.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# run_with_healthcheck.sh
+#
+# Starts CBF_tool_page.py via streamlit and restarts it if the
+# Streamlit healthcheck endpoint stops responding.
+#
+# Usage:
+#   ./run_with_healthcheck.sh [--port PORT] [--interval SECS] [--max-restarts N] [--streamlit-path /path/to/streamlit]
+#
+# Defaults:
+#   PORT            8501
+#   INTERVAL        30   (seconds between health polls)
+#   MAX_RESTARTS    0    (0 = unlimited)
+#   STREAMLIT_PATH "streamlit" (i.e. assumed to be in current $PATH)
+
+set -euo pipefail
+
+# ---------- defaults ----------------------------------------------------------
+PORT=8501
+INTERVAL=30
+MAX_RESTARTS=0
+HEALTH_URL="http://localhost:${PORT}/_stcore/health"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STREAMLIT_SCRIPT="${SCRIPT_DIR}/CBF_tool_page.py"
+STREAMLIT_PATH="streamlit"
+BACKOFF_INITIAL=5   # seconds to wait before first restart attempt
+BACKOFF_MAX=300     # cap on backoff delay
+
+# ---------- argument parsing --------------------------------------------------
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --port)        PORT="$2";         HEALTH_URL="http://localhost:${PORT}/_stcore/health"; shift 2 ;;
+        --interval)    INTERVAL="$2";     shift 2 ;;
+        --max-restarts) MAX_RESTARTS="$2"; shift 2 ;;
+	    --streamlit-path) STREAMLIT_PATH="$2"; shift 2;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+# ---------- helpers -----------------------------------------------------------
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"; }
+
+start_streamlit() {
+    log "Starting streamlit on port ${PORT}..."
+    ${STREAMLIT_PATH} run \
+        --server.port "${PORT}" \
+        --server.headless true \
+        "${STREAMLIT_SCRIPT}" &
+    STREAMLIT_PID=$!
+    log "Streamlit started (PID ${STREAMLIT_PID})"
+}
+
+stop_streamlit() {
+    if [[ -n "${STREAMLIT_PID:-}" ]] && kill -0 "${STREAMLIT_PID}" 2>/dev/null; then
+        log "Stopping streamlit (PID ${STREAMLIT_PID})..."
+        kill "${STREAMLIT_PID}"
+        wait "${STREAMLIT_PID}" 2>/dev/null || true
+    fi
+    STREAMLIT_PID=""
+}
+
+cleanup() {
+    log "Caught signal — shutting down."
+    stop_streamlit
+    exit 0
+}
+
+is_healthy() {
+    local http_code
+    http_code=$(curl -sf -o /dev/null -w "%{http_code}" \
+        --max-time 10 "${HEALTH_URL}" 2>/dev/null) || return 1
+    [[ "${http_code}" == "200" ]]
+}
+
+# ---------- main loop ---------------------------------------------------------
+trap cleanup SIGINT SIGTERM
+
+RESTART_COUNT=0
+BACKOFF=${BACKOFF_INITIAL}
+
+start_streamlit
+
+# Give streamlit a moment to initialise before the first health check.
+sleep "${BACKOFF_INITIAL}"
+
+while true; do
+    sleep "${INTERVAL}"
+
+    # Check whether the process is still alive.
+    if [[ -n "${STREAMLIT_PID:-}" ]] && ! kill -0 "${STREAMLIT_PID}" 2>/dev/null; then
+        log "WARNING: Streamlit process (PID ${STREAMLIT_PID}) has exited unexpectedly."
+        STREAMLIT_PID=""
+    fi
+
+    if ! is_healthy; then
+        log "WARNING: Health check failed for ${HEALTH_URL}"
+
+        RESTART_COUNT=$(( RESTART_COUNT + 1 ))
+        if [[ "${MAX_RESTARTS}" -gt 0 && "${RESTART_COUNT}" -gt "${MAX_RESTARTS}" ]]; then
+            log "ERROR: Reached maximum restart limit (${MAX_RESTARTS}). Exiting."
+            stop_streamlit
+            exit 1
+        fi
+
+        log "Restart #${RESTART_COUNT} — waiting ${BACKOFF}s before restarting..."
+        stop_streamlit
+        sleep "${BACKOFF}"
+
+        # Exponential backoff, capped at BACKOFF_MAX.
+        BACKOFF=$(( BACKOFF * 2 ))
+        [[ "${BACKOFF}" -gt "${BACKOFF_MAX}" ]] && BACKOFF="${BACKOFF_MAX}"
+
+        start_streamlit
+        sleep "${BACKOFF_INITIAL}"   # grace period for new process to come up
+    else
+        # Healthy — reset backoff.
+        BACKOFF=${BACKOFF_INITIAL}
+    fi
+done

--- a/util/templates/cask_end_template.tt2
+++ b/util/templates/cask_end_template.tt2
@@ -18,7 +18,7 @@ max_units_per_sale variables below. %]
 
 [% IF dump_class == 'product_order' -%]
 [%- FILTER stderr -%]
-Note that cask end signs created using product_order dump class info may be inaccurate, due to read-world discrepancies in actual cask delivery.
+Note that cask end signs created using product_order dump class info may be inaccurate, due to real-world discrepancies in actual cask delivery.
 [% END -%]
 [%- END %]
 


### PR DESCRIPTION
Adds a bash wrapper script that handles restart of streamlit if the healthcheck fails.

Also adds a timestamp to the latest cask ID query (giving some reassurance that the value is current). We may decide to remove this again in future if we can make the rest of the app bulletproof.

Note that this is already running in production; this PR is just to store it for later redeployments.

Also included: A couple of minor typos, and a fix for a bug in PriceMunger decode_json_changes which failed when trying to delete a cask.