### PR TITLE
Password reset handling

### DIFF
--- a/beerfestdb_web_site.yml
+++ b/beerfestdb_web_site.yml
@@ -112,3 +112,9 @@ Plugin::CSRFToken:
   max_age: 3600, # Token lifespan in seconds
   auto_check: 1,
   default_secret: 'a very long and secret string that should be overridden in production',
+
+# Email configuration for password reset messages.
+email:
+  from_address: 'beerfestdb@example.com'
+  smtp_host:    'localhost'
+  smtp_port:    25

--- a/cpanfile
+++ b/cpanfile
@@ -14,6 +14,8 @@ requires 'Catalyst::View::JSON';
 requires 'Catalyst::View::TT';
 requires 'Digest::SHA',                                    '6.04';
 requires 'Crypt::SaltedHash',                              '0.09';
+requires 'Bytes::Random::Secure';
+requires 'MIME::Lite::TT::HTML';
 requires 'Config::YAML';
 requires 'JSON::MaybeXS';
 requires 'Cpanel::JSON::XS';

--- a/db/create_tables.sql
+++ b/db/create_tables.sql
@@ -1327,6 +1327,27 @@ CREATE TABLE `user_role` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
+-- Table structure for table `password_reset_token`
+--
+
+DROP TABLE IF EXISTS `password_reset_token`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `password_reset_token` (
+  `token_id`    INT(11)      NOT NULL AUTO_INCREMENT,
+  `user_id`     INT(11)      NOT NULL,
+  `token_hash`  VARCHAR(64)  NOT NULL,
+  `expires_at`  DATETIME     NOT NULL,
+  `used`        TINYINT(1)   NOT NULL DEFAULT 0,
+  `created_at`  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`token_id`),
+  UNIQUE KEY `token_hash` (`token_hash`),
+  KEY `user_id` (`user_id`),
+  CONSTRAINT `prt_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `user` (`user_id`) ON DELETE CASCADE ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
 -- Final view structure for view `order_summary_view`
 --
 

--- a/db/migrations/20260515_add_password_reset_token_table.sql
+++ b/db/migrations/20260515_add_password_reset_token_table.sql
@@ -1,0 +1,28 @@
+-- Migration: Add password_reset_token table for email-based password reset
+-- Date: 2026-05-15
+
+SET @exists := (
+  SELECT COUNT(*)
+  FROM information_schema.TABLES
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME   = 'password_reset_token'
+);
+SET @sql := IF(@exists = 0,
+  'CREATE TABLE `password_reset_token` (
+    `token_id`    INT(11)      NOT NULL AUTO_INCREMENT,
+    `user_id`     INT(11)      NOT NULL,
+    `token_hash`  VARCHAR(64)  NOT NULL,
+    `expires_at`  DATETIME     NOT NULL,
+    `used`        TINYINT(1)   NOT NULL DEFAULT 0,
+    `created_at`  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`token_id`),
+    UNIQUE KEY `token_hash` (`token_hash`),
+    KEY `user_id` (`user_id`),
+    CONSTRAINT `prt_ibfk_1` FOREIGN KEY (`user_id`)
+      REFERENCES `user` (`user_id`) ON DELETE CASCADE ON UPDATE NO ACTION
+  ) ENGINE=InnoDB DEFAULT CHARSET=utf8',
+  'SELECT "password_reset_token already exists"'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- End of migration

--- a/lib/BeerFestDB/ORM/PasswordResetToken.pm
+++ b/lib/BeerFestDB/ORM/PasswordResetToken.pm
@@ -1,0 +1,36 @@
+use utf8;
+package BeerFestDB::ORM::PasswordResetToken;
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
+
+__PACKAGE__->table("password_reset_token");
+
+__PACKAGE__->add_columns(
+  "token_id",
+  { data_type => "integer", is_auto_increment => 1, is_nullable => 0 },
+  "user_id",
+  { data_type => "integer", is_nullable => 0 },
+  "token_hash",
+  { data_type => "varchar", is_nullable => 0, size => 64 },
+  "expires_at",
+  { data_type => "datetime", is_nullable => 0 },
+  "used",
+  { data_type => "tinyint", default_value => 0, is_nullable => 0 },
+  "created_at",
+  { data_type => "datetime", is_nullable => 0, default_value => \"CURRENT_TIMESTAMP" },
+);
+
+__PACKAGE__->set_primary_key("token_id");
+
+__PACKAGE__->add_unique_constraint("token_hash", ["token_hash"]);
+
+__PACKAGE__->belongs_to(
+  "user",
+  "BeerFestDB::ORM::User",
+  { "foreign.user_id" => "self.user_id" },
+);
+
+1;

--- a/lib/BeerFestDB/ORM/User.pm
+++ b/lib/BeerFestDB/ORM/User.pm
@@ -152,6 +152,12 @@ __PACKAGE__->many_to_many(
     "roles" => "user_roles", "role_id"
 );
 
+__PACKAGE__->has_many(
+  "password_reset_tokens",
+  "BeerFestDB::ORM::PasswordResetToken",
+  { "foreign.user_id" => "self.user_id" },
+);
+
 sub repr {
     my ( $self ) = @_; return $self->username;
 }

--- a/lib/BeerFestDB/Web.pm
+++ b/lib/BeerFestDB/Web.pm
@@ -158,11 +158,16 @@ foreach my $path ( qw(bayposition companyregion contacttype containermeasure
 }
 
 __PACKAGE__->allow_access_if( '/user', [ qw( admin ) ] );
-__PACKAGE__->allow_access( '/user/modify' );    # User-level account modification.
-__PACKAGE__->allow_access( '/user/load_form' ); # Maintains its own access config.
+__PACKAGE__->allow_access( '/user/modify' );               # User-level account modification.
+__PACKAGE__->allow_access( '/user/load_form' );            # Maintains its own access config.
+__PACKAGE__->allow_access( '/user/view' );                 # Ownership checked in action.
+__PACKAGE__->allow_access( '/user/request_password_reset' ); # Ownership checked in action.
+__PACKAGE__->allow_access( '/user/reset_password' );       # Token-based; no login required.
+__PACKAGE__->allow_access( '/user/reset_password_submit' ); # Token-based; no login required.
 __PACKAGE__->deny_access( '/user' );
 
 __PACKAGE__->allow_access_if( '/role', [ qw( admin ) ] );
+__PACKAGE__->allow_access( '/role/list' );               # Role listings only
 __PACKAGE__->deny_access( '/role' );
 
 # Areas to which access is always granted.

--- a/lib/BeerFestDB/Web.pm
+++ b/lib/BeerFestDB/Web.pm
@@ -150,25 +150,23 @@ foreach my $path ( qw(productstyle) ) {
 foreach my $path ( qw(bayposition companyregion contacttype containermeasure
                       containersize country currency dispensemethod
                       productallergentype productcharacteristictype
-                      productcategory productstyle
+                      productcategory productstyle role
                       salevolume telephonetype) ) {
     __PACKAGE__->allow_access_if( "/$path/list", [ qw( user ) ] );
     __PACKAGE__->allow_access_if( '/' . $path, [ qw( admin ) ] );
     __PACKAGE__->deny_access( '/' . $path );
 }
 
+# Special handling for user management: users can edit their own account but only admins
+# can edit other accounts or assign roles.
 __PACKAGE__->allow_access_if( '/user', [ qw( admin ) ] );
-__PACKAGE__->allow_access( '/user/modify' );               # User-level account modification.
-__PACKAGE__->allow_access( '/user/load_form' );            # Maintains its own access config.
-__PACKAGE__->allow_access( '/user/view' );                 # Ownership checked in action.
+__PACKAGE__->allow_access( '/user/modify' );                 # User-level account modification.
+__PACKAGE__->allow_access( '/user/load_form' );              # Maintains its own access config.
+__PACKAGE__->allow_access( '/user/view' );                   # Ownership checked in action.
 __PACKAGE__->allow_access( '/user/request_password_reset' ); # Ownership checked in action.
-__PACKAGE__->allow_access( '/user/reset_password' );       # Token-based; no login required.
-__PACKAGE__->allow_access( '/user/reset_password_submit' ); # Token-based; no login required.
+__PACKAGE__->allow_access( '/user/reset_password' );         # Token-based; no login required.
+__PACKAGE__->allow_access( '/user/reset_password_submit' );  # Token-based; no login required.
 __PACKAGE__->deny_access( '/user' );
-
-__PACKAGE__->allow_access_if( '/role', [ qw( admin ) ] );
-__PACKAGE__->allow_access( '/role/list' );               # Role listings only
-__PACKAGE__->deny_access( '/role' );
 
 # Areas to which access is always granted.
 __PACKAGE__->allow_access( '/default' );

--- a/lib/BeerFestDB/Web/Controller/User.pm
+++ b/lib/BeerFestDB/Web/Controller/User.pm
@@ -87,12 +87,25 @@ sub view : Local {
 
     my ( $self, $c, $id ) = @_;
 
+    unless ( $c->user_exists ) {
+        $c->flash->{url_success_target} = '' . $c->req->uri;
+        $c->res->redirect( $c->uri_for('/login') );
+        $c->detach();
+    }
+
+    unless ( defined $id
+          && $id == eval { $c->user->user_id }
+          || $c->check_any_user_role('admin') ) {
+        $c->stash->{error} = 'You are not authorised to access these data.';
+        $c->detach( '/access_denied' );
+    }
+
     my $object = $c->model('DB::User')->find($id);
 
     unless ( $object ) {
         $c->flash->{error} = "Error: User not found.";
         $c->res->redirect( $c->uri_for('/default') );
-        $c->detach();        
+        $c->detach();
     }
 
     $c->stash->{object} = $object;
@@ -149,20 +162,26 @@ sub build_database_object : Private {
 
     my $obj = $self->next::method( $rec, $c, @other );
 
+    # Quietly drop role changes attempted by non-admin users 
     if ( defined $roles && defined $obj ) {
-        my $rs = $c->model( 'DB::UserRole' );
-        my @r = split /,/, $roles;
-        foreach my $existing ($obj->user_roles) {
+        if ( $c->check_any_user_role('admin') ) {
+            $c->log->debug("Updating roles for user_id " . $obj->user_id() . ": $roles");
+            my $rs = $c->model( 'DB::UserRole' );
+            my @r = split /,/, $roles;
+            foreach my $existing ($obj->user_roles) {
 
-            # Delete unwanted existing roles.
-            if ( ! first { $existing->get_column('role_id') == $_ } @r ) {
-                $existing->delete;
+                # Delete unwanted existing roles.
+                if ( ! first { $existing->get_column('role_id') == $_ } @r ) {
+                    $existing->delete;
+                }
             }
-        }
-        foreach my $role_id (@r) {
+            foreach my $role_id (@r) {
 
-            # Check that all the wanted roles are set.
-            $rs->find_or_create({ user_id => $obj->user_id(), role_id => $role_id });
+                # Check that all the wanted roles are set.
+                $rs->find_or_create({ user_id => $obj->user_id(), role_id => $role_id });
+            }
+        } else {
+            $c->flash->{error} = 'Role changes ignored (unauthorised).';
         }
     }
 
@@ -200,9 +219,9 @@ sub load_form : Local {
 =head2 modify
 
 Profile self-edit: allows a logged-in user to update their own C<name>
-and C<email>. Password, username and roles cannot be changed via this
-action; use C<request_password_reset> for password changes and the
-admin C<submit> action for role management.
+and C<email>. Username and roles cannot be changed via this action.
+Admin users may also set a new C<password> here; non-admin users must
+use C<request_password_reset> for password changes.
 
 =cut
 
@@ -224,7 +243,8 @@ sub modify : Local {
         }
 
         # Strip fields that must not be changed via this action.
-        delete $rec->{$_} for qw( username password roles );
+        delete $rec->{$_} for qw( username roles );
+        delete $rec->{'password'} unless $c->check_any_user_role('admin');
     }
 
     my $rs = $c->model( 'DB::User' );

--- a/lib/BeerFestDB/Web/Controller/User.pm
+++ b/lib/BeerFestDB/Web/Controller/User.pm
@@ -26,6 +26,11 @@ use namespace::autoclean;
 use Crypt::SaltedHash;
 use List::Util qw(first);
 use JSON::MaybeXS;
+use Bytes::Random::Secure qw(random_bytes);
+use Digest::SHA qw(sha256_hex);
+use MIME::Base64 qw(encode_base64url);
+use MIME::Lite::TT::HTML;
+use DateTime;
 
 BEGIN {extends 'BeerFestDB::Web::Controller'; }
 
@@ -192,26 +197,284 @@ sub load_form : Local {
     $self->form_json_and_detach( $c, $rs, $pk );
 }
 
-# FIXME this is just a vague outline at the moment. It's intended as a
-# means for a given user to be able to edit their own account
-# (e.g. change password).
+=head2 modify
+
+Profile self-edit: allows a logged-in user to update their own C<name>
+and C<email>. Password, username and roles cannot be changed via this
+action; use C<request_password_reset> for password changes and the
+admin C<submit> action for role management.
+
+=cut
+
 sub modify : Local {
 
     my ( $self, $c ) = @_;
 
-    # Quick check for authorisation; we may need to put in other
-    # checks for content FIXME.
     my $data = $self->decode_json_changes($c);
 
     foreach my $rec ( @{ $data } ) {
-        if ( $rec->{'user_id'} != eval{ $c->user->user_id } ) {
+
+        my $target_id = $rec->{'user_id'};
+
+        unless ( defined $target_id
+              && $target_id == eval { $c->user->user_id }
+              || $c->check_any_user_role('admin') ) {
             $c->stash->{error} = 'You are not authorised to edit these data.';
             $c->detach( '/access_denied' );
         }
+
+        # Strip fields that must not be changed via this action.
+        delete $rec->{$_} for qw( username password roles );
     }
 
-    # Pass-through to submit action for the moment FIXME?
-    $self->submit( $c );
+    my $rs = $c->model( 'DB::User' );
+    $self->write_to_resultset( $c, $rs );
+}
+
+=head2 request_password_reset
+
+Generates a single-use, time-limited (15-minute) password-reset token,
+stores its SHA-256 hash in the database, and emails the raw token to
+the user's registered address.
+
+=cut
+
+sub request_password_reset : Local {
+
+    my ( $self, $c ) = @_;
+
+    # Must be logged in, or an admin acting on another user's behalf.
+    unless ( $c->user_exists ) {
+        $c->stash->{error} = 'You must be logged in to request a password reset.';
+        $c->detach( '/access_denied' );
+    }
+
+    my $user_id = $c->request->param('user_id');
+    unless ( defined $user_id && $user_id =~ /^\d+$/ ) {
+        $c->stash->{error} = 'Invalid user_id.';
+        $c->detach( '/access_denied' );
+    }
+
+    unless ( $user_id == eval { $c->user->user_id }
+          || $c->check_any_user_role('admin') ) {
+        $c->stash->{error} = 'You are not authorised to reset this password.';
+        $c->detach( '/access_denied' );
+    }
+
+    my $user = $c->model('DB::User')->find( $user_id );
+    unless ( $user ) {
+        $c->stash->{ success } = JSON->false();
+        $c->stash->{ error }   = 'User not found.';
+        $c->forward( 'View::JSON' );
+        return;
+    }
+
+    my $email_addr = $user->email;
+    unless ( defined $email_addr && $email_addr ne q{} ) {
+        $c->stash->{ success } = JSON->false();
+        $c->stash->{ error }   = 'No email address is registered for this account.';
+        $c->forward( 'View::JSON' );
+        return;
+    }
+
+    # Remove any existing unused tokens for this user.
+    $c->model('DB::PasswordResetToken')->search({
+        user_id => $user_id,
+        used    => 0,
+    })->delete;
+
+    # Generate a cryptographically secure random token.
+    my $raw_token  = encode_base64url( random_bytes(32) );
+    my $token_hash = sha256_hex( $raw_token );
+    my $expires_at = DateTime->now->add( minutes => 15 );
+    my $expires_str = sprintf( '%04d-%02d-%02d %02d:%02d:%02d',
+        $expires_at->year, $expires_at->month,  $expires_at->day,
+        $expires_at->hour, $expires_at->minute, $expires_at->second );
+
+    $c->model('DB::PasswordResetToken')->create({
+        user_id    => $user_id,
+        token_hash => $token_hash,
+        expires_at => $expires_str,
+        used       => 0,
+    });
+
+    my $reset_url = $c->uri_for( '/user/reset_password', { token => $raw_token } )->as_string;
+
+    my $email_cfg = $c->config->{ email } || {};
+    my $from      = $email_cfg->{ from_address } || 'beerfestdb@localhost';
+    my $smtp_host = $email_cfg->{ smtp_host }    || 'localhost';
+    my $smtp_port = $email_cfg->{ smtp_port }    || 25;
+
+    eval {
+        my $tt_vars = {
+            username  => $user->username,
+            reset_url => $reset_url,
+            expires   => '15 minutes',
+        };
+        my $msg = MIME::Lite::TT::HTML->new(
+            From     => $from,
+            To       => $email_addr,
+            Subject  => 'BeerFestDB password reset',
+            Template => {
+                text => 'email/password_reset_text.tt2',
+                html => 'email/password_reset_html.tt2',
+            },
+            TmplOptions => { INCLUDE_PATH => $c->path_to('root', 'src') },
+            TmplParams  => $tt_vars,
+        );
+        $msg->send( 'smtp', $smtp_host, Port => $smtp_port );
+    };
+    if ( $@ ) {
+        $c->log->error( "Failed to send password reset email: $@" );
+        $c->stash->{ success } = JSON->false();
+        $c->stash->{ error }   = 'Failed to send password reset email. Please contact an administrator.';
+        $c->forward( 'View::JSON' );
+        return;
+    }
+
+    $c->stash->{ success } = JSON->true();
+    $c->forward( 'View::JSON' );
+}
+
+=head2 reset_password
+
+Renders the password reset form. Validates the raw token supplied in
+C<?token=...> before displaying the form; redirects to the login page
+if the token is absent, already used, or expired.
+
+=cut
+
+sub reset_password : Local {
+
+    my ( $self, $c ) = @_;
+
+    my $raw_token = $c->request->param('token');
+
+    my $token_row = $self->_validate_reset_token( $c, $raw_token )
+        or return;   # _validate_reset_token handles redirect on failure
+
+    $c->stash->{token}    = $raw_token;
+    $c->stash->{username} = $token_row->user->username;
+    $c->stash->{template} = 'user/reset_password.tt2';
+}
+
+=head2 reset_password_submit
+
+Handles submission of the password reset form. Re-validates the token
+inside a transaction, hashes the new password, updates the user record,
+and marks the token as used.
+
+=cut
+
+sub reset_password_submit : Local {
+
+    my ( $self, $c ) = @_;
+
+    my $raw_token   = $c->request->param('token');
+    my $new_pw      = $c->request->param('new_password');
+    my $confirm_pw  = $c->request->param('confirm_password');
+
+    unless ( defined $new_pw && $new_pw ne q{} ) {
+        $c->flash->{error} = 'Password must not be empty.';
+        $c->res->redirect( $c->uri_for( '/user/reset_password', { token => $raw_token } ) );
+        $c->detach();
+    }
+
+    unless ( $new_pw eq $confirm_pw ) {
+        $c->flash->{error} = 'Passwords do not match.';
+        $c->res->redirect( $c->uri_for( '/user/reset_password', { token => $raw_token } ) );
+        $c->detach();
+    }
+
+    my $schema = $c->model('DB::User')->result_source->schema;
+
+    my $error;
+    eval {
+        $schema->txn_do( sub {
+
+            # Re-validate inside the transaction to guard against races.
+            my $token_row = $self->_validate_reset_token( $c, $raw_token )
+                or die "invalid token\n";
+
+            my $csh = Crypt::SaltedHash->new( algorithm => 'SHA-1' );
+            $csh->add( $new_pw );
+            my $hashed_pw = $csh->generate();
+
+            $token_row->user->update({
+                password             => $hashed_pw,
+                date_password_changed => \'CURRENT_TIMESTAMP',
+                date_modified        => \'CURRENT_TIMESTAMP',
+            });
+
+            $token_row->update({ used => 1 });
+        });
+    };
+    if ( $@ && $@ ne "invalid token\n" ) {
+        $c->log->error( "Password reset transaction failed: $@" );
+        $c->flash->{error} = 'An error occurred while resetting your password. Please try again.';
+        $c->res->redirect( $c->uri_for( '/user/reset_password', { token => $raw_token } ) );
+        $c->detach();
+    }
+
+    # On success (or handled invalid-token redirect from _validate_reset_token):
+    unless ( $error ) {
+        $c->flash->{message} = 'Your password has been updated. Please log in with your new password.';
+        $c->res->redirect( $c->uri_for('/login') );
+        $c->detach();
+    }
+}
+
+# ------------------------------------------------------------------
+# Private helper
+
+sub _validate_reset_token : Private {
+
+    my ( $self, $c, $raw_token ) = @_;
+
+    unless ( defined $raw_token && $raw_token ne q{} ) {
+        $c->flash->{error} = 'No reset token provided.';
+        $c->res->redirect( $c->uri_for('/login') );
+        $c->detach();
+        return;
+    }
+
+    my $token_hash = sha256_hex( $raw_token );
+    my $token_row  = $c->model('DB::PasswordResetToken')->find({ token_hash => $token_hash });
+
+    unless ( $token_row ) {
+        $c->flash->{error} = 'Invalid or expired password reset link.';
+        $c->res->redirect( $c->uri_for('/login') );
+        $c->detach();
+        return;
+    }
+
+    if ( $token_row->used ) {
+        $c->flash->{error} = 'This password reset link has already been used.';
+        $c->res->redirect( $c->uri_for('/login') );
+        $c->detach();
+        return;
+    }
+
+    # Compare expiry in UTC.
+    my $now     = DateTime->now;
+    my $expires = $token_row->expires_at;
+    # expires_at comes back as a string from the DB; parse it.
+    if ( ! ref $expires ) {
+        my ( $y, $mo, $d, $h, $mi, $s ) = split /\D+/, $expires;
+        $expires = DateTime->new(
+            year => $y, month => $mo, day => $d,
+            hour => $h, minute => $mi, second => $s,
+        );
+    }
+
+    if ( DateTime->compare( $now, $expires ) >= 0 ) {
+        $c->flash->{error} = 'This password reset link has expired. Please request a new one.';
+        $c->res->redirect( $c->uri_for('/login') );
+        $c->detach();
+        return;
+    }
+
+    return $token_row;
 }
 
 sub generate_object_viewhash : Private {

--- a/root/lib/site/html
+++ b/root/lib/site/html
@@ -111,6 +111,8 @@
    var url_role_delete          = '[% c.uri_for( "/role/delete" ) %]';
    var url_user_submit          = '[% c.uri_for( "/user/submit" ) %]';
    var url_user_delete          = '[% c.uri_for( "/user/delete" ) %]';
+   var url_user_modify                  = '[% c.uri_for( "/user/modify" ) %]';
+   var url_user_request_password_reset  = '[% c.uri_for( "/user/request_password_reset" ) %]';
 
    var url_product_index        = '[% c.uri_for( "/product" ) %]';
 

--- a/root/src/email/password_reset_html.tt2
+++ b/root/src/email/password_reset_html.tt2
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>BeerFestDB Password Reset</title>
+  <style>
+    body { font-family: Arial, sans-serif; font-size: 14px; color: #333; }
+    .container { max-width: 600px; margin: 30px auto; padding: 20px;
+                 border: 1px solid #ddd; border-radius: 4px; }
+    .button { display: inline-block; padding: 10px 20px; background: #2c6fad;
+              color: #fff; text-decoration: none; border-radius: 3px; }
+    .footer { margin-top: 30px; font-size: 12px; color: #888; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <p>Dear [% username | html %],</p>
+    <p>A password reset has been requested for your BeerFestDB account.</p>
+    <p>Click the button below to reset your password. The link will expire
+       in <strong>[% expires | html %]</strong>.</p>
+    <p>
+      <a class="button" href="[% reset_url | html %]">Reset my password</a>
+    </p>
+    <p>Or copy and paste this URL into your browser:</p>
+    <p><a href="[% reset_url | html %]">[% reset_url | html %]</a></p>
+    <p>If you did not request a password reset, you can safely ignore this
+       email. Your password will not be changed.</p>
+    <div class="footer">BeerFestDB</div>
+  </div>
+</body>
+</html>

--- a/root/src/email/password_reset_text.tt2
+++ b/root/src/email/password_reset_text.tt2
@@ -1,0 +1,15 @@
+Dear [% username %],
+
+A password reset has been requested for your BeerFestDB account.
+
+To reset your password, please click the link below (or paste it into
+your browser). The link will expire in [% expires %].
+
+  [% reset_url %]
+
+If you did not request a password reset, you can safely ignore this
+email. Your password will not be changed unless you follow the link
+above and complete the process.
+
+-- 
+BeerFestDB

--- a/root/src/index.tt2
+++ b/root/src/index.tt2
@@ -1,23 +1,16 @@
 [% META title = "Welcome to BeerFestDB" %]
 
+[% css_link( href = '/static/css/bfdb-pages.css' ) %]
 <style type="text/css">
-  #bfdb-hero {
-    background: linear-gradient(135deg, #b35c00 0%, #e8890a 60%, #f5b942 100%);
+  /* index-specific */
+  .bfdb-user-bar {
+    margin: 0.9em 0 0;
+    font-size: 0.85em;
+    opacity: 0.88;
+  }
+  .bfdb-user-bar a {
     color: #fff;
-    text-align: center;
-    padding: 2.5em 1em 2em;
-    margin-bottom: 0;
-  }
-  #bfdb-hero h1 {
-    margin: 0 0 0.4em;
-    font-size: 2em;
-    letter-spacing: 0.03em;
-    text-shadow: 0 1px 3px rgba(0,0,0,0.35);
-  }
-  #bfdb-hero p {
-    margin: 0;
-    font-size: 1em;
-    opacity: 0.92;
+    text-decoration: underline;
   }
   #bfdb-panels {
     display: flex;
@@ -27,26 +20,7 @@
     margin: 0 auto;
     box-sizing: border-box;
   }
-  .bfdb-panel {
-    flex: 1;
-    background: #fff;
-    border-radius: 6px;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.13);
-    padding: 1.5em;
-    box-sizing: border-box;
-  }
-  .bfdb-panel h2 {
-    margin: 0 0 0.8em;
-    font-size: 1.1em;
-    padding-left: 0.6em;
-    border-left: 4px solid #e8890a;
-    color: #333;
-  }
-  .bfdb-panel > p {
-    font-size: 0.9em;
-    color: #555;
-    margin: 0 0 1em;
-  }
+  .bfdb-panel { flex: 1; }
   .bfdb-card {
     display: block;
     padding: 0.55em 0.9em;
@@ -89,6 +63,13 @@
   [% ELSE %]
     <p>Beer festival product management &mdash; use the panels below to navigate.</p>
   [% END %]
+  [% IF c.user_exists %]
+  <p class="bfdb-user-bar">Logged in as <strong>[% c.user.username | html %]</strong>
+    &mdash; <a href="[% c.uri_for('/user/view', c.user.user_id) %]">My Account</a>
+    &bull; <a href="[% c.uri_for('/logout') %]">Log out</a></p>
+  [% ELSE %]
+  <p class="bfdb-user-bar"><a href="[% c.uri_for('/login') %]">Log in</a></p>
+  [% END %]
 </div>
 
 <div id="bfdb-panels">
@@ -100,6 +81,7 @@
     <a class="bfdb-card" href="[% c.uri_for('/company/grid') %]">Supplier and Product Listings</a>
   </div>
 
+  [% IF c.check_any_user_role('admin') %]
   <div class="bfdb-panel" id="bfdb-admin-menu">
     <h2>Database Administration</h2>
     <p>Configuration pages restricted to admin-level users.</p>
@@ -127,6 +109,7 @@
       <a class="bfdb-card" href="[% c.uri_for('/currency/grid') %]">Currencies</a>
     </div>
   </div>
+  [% END %]
 
 </div>
 

--- a/root/src/user/reset_password.tt2
+++ b/root/src/user/reset_password.tt2
@@ -1,32 +1,101 @@
 [% META title = 'Reset Password' %]
 
-[% IF c.flash.error %]
-<p class="error-message">[% c.flash.error | html %]</p>
-[% END %]
+[% css_link( href = '/static/css/bfdb-pages.css' ) %]
+<style type="text/css">
+  /* reset-password-specific */
+  #bfdb-content {
+    display: flex;
+    justify-content: center;
+    padding: 2em 1em;
+  }
+  .bfdb-panel {
+    padding: 1.8em 2em;
+    width: 100%;
+    max-width: 420px;
+  }
+  .bfdb-error {
+    background: #fff0f0;
+    border: 1px solid #e00;
+    border-radius: 4px;
+    color: #c00;
+    font-size: 0.9em;
+    padding: 0.6em 0.9em;
+    margin-bottom: 1.1em;
+  }
+  .bfdb-field {
+    margin-bottom: 1em;
+  }
+  .bfdb-field label {
+    display: block;
+    font-size: 0.88em;
+    color: #555;
+    margin-bottom: 0.3em;
+  }
+  .bfdb-field input[type="password"] {
+    width: 100%;
+    padding: 0.5em 0.7em;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 0.95em;
+    box-sizing: border-box;
+  }
+  .bfdb-field input[type="password"]:focus {
+    outline: none;
+    border-color: #e8890a;
+    box-shadow: 0 0 0 2px rgba(232,137,10,0.2);
+  }
+  .bfdb-submit {
+    display: inline-block;
+    margin-top: 0.5em;
+    padding: 0.55em 1.4em;
+    background: #e8890a;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    font-size: 0.95em;
+    cursor: pointer;
+    transition: background 0.15s;
+  }
+  .bfdb-submit:hover {
+    background: #b35c00;
+  }
+</style>
 
-<div class="reset-password-form">
-  <h2>Reset Password</h2>
-  <p>Enter a new password for account <strong>[% username | html %]</strong>.</p>
+<div id="html-content">
 
-  <form method="post" action="[% c.uri_for('/user/reset_password_submit') %]">
-    <input type="hidden" name="token" value="[% token | html %]">
-    <input type="hidden" name="csrf_token" value="[% c.csrf_token %]">
+<div id="bfdb-hero">
+  <h1>BeerFestDB</h1>
+  <p>Set a new password for your account.</p>
+</div>
 
-    <table>
-      <tr>
-        <td><label for="new_password">New password:</label></td>
-        <td><input type="password" id="new_password" name="new_password"
-                   required autocomplete="new-password"></td>
-      </tr>
-      <tr>
-        <td><label for="confirm_password">Confirm password:</label></td>
-        <td><input type="password" id="confirm_password" name="confirm_password"
-                   required autocomplete="new-password"></td>
-      </tr>
-      <tr>
-        <td></td>
-        <td><button type="submit">Set new password</button></td>
-      </tr>
-    </table>
-  </form>
+<div id="bfdb-content">
+  <div class="bfdb-panel">
+    <h2>Reset Password</h2>
+    <p>Enter a new password for account <strong>[% username | html %]</strong>.</p>
+
+    [% IF c.flash.error %]
+    <div class="bfdb-error">[% c.flash.error | html %]</div>
+    [% END %]
+
+    <form method="post" action="[% c.uri_for('/user/reset_password_submit') %]">
+      <input type="hidden" name="token" value="[% token | html %]">
+      <input type="hidden" name="csrf_token" value="[% c.csrf_token %]">
+
+      <div class="bfdb-field">
+        <label for="new_password">New password</label>
+        <input type="password" id="new_password" name="new_password"
+               required autocomplete="new-password">
+      </div>
+
+      <div class="bfdb-field">
+        <label for="confirm_password">Confirm password</label>
+        <input type="password" id="confirm_password" name="confirm_password"
+               required autocomplete="new-password">
+      </div>
+
+      <button type="submit" class="bfdb-submit">Set new password</button>
+    </form>
+  </div>
+</div>
+
 </div>

--- a/root/src/user/reset_password.tt2
+++ b/root/src/user/reset_password.tt2
@@ -1,0 +1,32 @@
+[% META title = 'Reset Password' %]
+
+[% IF c.flash.error %]
+<p class="error-message">[% c.flash.error | html %]</p>
+[% END %]
+
+<div class="reset-password-form">
+  <h2>Reset Password</h2>
+  <p>Enter a new password for account <strong>[% username | html %]</strong>.</p>
+
+  <form method="post" action="[% c.uri_for('/user/reset_password_submit') %]">
+    <input type="hidden" name="token" value="[% token | html %]">
+    <input type="hidden" name="csrf_token" value="[% c.csrf_token %]">
+
+    <table>
+      <tr>
+        <td><label for="new_password">New password:</label></td>
+        <td><input type="password" id="new_password" name="new_password"
+                   required autocomplete="new-password"></td>
+      </tr>
+      <tr>
+        <td><label for="confirm_password">Confirm password:</label></td>
+        <td><input type="password" id="confirm_password" name="confirm_password"
+                   required autocomplete="new-password"></td>
+      </tr>
+      <tr>
+        <td></td>
+        <td><button type="submit">Set new password</button></td>
+      </tr>
+    </table>
+  </form>
+</div>

--- a/root/src/user/view.tt2
+++ b/root/src/user/view.tt2
@@ -4,6 +4,7 @@
    var url_user_grid      = '[% c.uri_for( "/user/grid" ) %]';
    var url_user_load_form = '[% c.uri_for( "/user/load_form" ) %]';
    var user_id            = '[% object.id %]';
+   var user_is_admin      = [% c.check_any_user_role('admin') ? 'true' : 'false' %];
 </script>
 
 [% js_link( src = '/static/js/grids/user_view.js' ) %]

--- a/root/static/css/bfdb-pages.css
+++ b/root/static/css/bfdb-pages.css
@@ -1,0 +1,50 @@
+/*
+ * Shared styles for plain-HTML BeerFestDB pages (index, reset_password, etc.)
+ */
+
+/* ── Hero banner ─────────────────────────────────────────────────────────── */
+
+#bfdb-hero {
+  background: linear-gradient(135deg, #b35c00 0%, #e8890a 60%, #f5b942 100%);
+  color: #fff;
+  text-align: center;
+  padding: 2.5em 1em 2em;
+  margin-bottom: 0;
+}
+
+#bfdb-hero h1 {
+  margin: 0 0 0.4em;
+  font-size: 2em;
+  letter-spacing: 0.03em;
+  text-shadow: 0 1px 3px rgba(0,0,0,0.35);
+}
+
+#bfdb-hero p {
+  margin: 0;
+  font-size: 1em;
+  opacity: 0.92;
+}
+
+/* ── Content card ────────────────────────────────────────────────────────── */
+
+.bfdb-panel {
+  background: #fff;
+  border-radius: 6px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.13);
+  padding: 1.5em;
+  box-sizing: border-box;
+}
+
+.bfdb-panel h2 {
+  margin: 0 0 0.8em;
+  font-size: 1.1em;
+  padding-left: 0.6em;
+  border-left: 4px solid #e8890a;
+  color: #333;
+}
+
+.bfdb-panel > p {
+  font-size: 0.9em;
+  color: #555;
+  margin: 0 0 1em;
+}

--- a/root/static/js/grids/product_order.js
+++ b/root/static/js/grids/product_order.js
@@ -261,7 +261,7 @@ Ext.onReady(function(){
               allowBlank:     true,
           })},
         { id:         'price',
-          header:     'Price',
+          header:     'Total Price',
           dataIndex:  'price',
           width:      50,
           editor:     new Ext.form.TextField({

--- a/root/static/js/grids/product_order_view.js
+++ b/root/static/js/grids/product_order_view.js
@@ -159,7 +159,7 @@ Ext.onReady(function(){
               allowBlank:     true },
 
             { name:           'price',
-              fieldLabel:     'Sale Price',
+              fieldLabel:     'Total Price',
               xtype:          'textfield',
               allowBlank:     true, },
             

--- a/root/static/js/grids/user_view.js
+++ b/root/static/js/grids/user_view.js
@@ -45,7 +45,7 @@ Ext.onReady(function(){
     /* User form */
     var userForm = new MyFormPanel({
 
-        url:         url_user_submit,
+        url:         url_user_modify,
         title:       'User details',
             
         items: [
@@ -54,11 +54,6 @@ Ext.onReady(function(){
               fieldLabel:     'Username',
               xtype:          'textfield',
               readOnly:       true, },
-            
-            { name:           'password',
-              fieldLabel:     'Password',
-              xtype:          'textfield',
-              allowBlank:     true, },
             
             { name:           'name',
               fieldLabel:     'Real name',
@@ -115,6 +110,30 @@ Ext.onReady(function(){
         [
             { text: 'Home', handler: function() { window.location = url_base; } },
             { text: 'Users', handler: function() { window.location = url_user_grid; } },
+            { xtype: 'tbseparator' },
+            { text:    'Send password reset email',
+              iconCls: 'icon-email',
+              tooltip: 'Email a password reset link to this user\'s registered address',
+              handler: function() {
+                  Ext.Ajax.request({
+                      url:     url_user_request_password_reset,
+                      params:  { user_id: user_id },
+                      success: function(response) {
+                          var result = Ext.util.JSON.decode(response.responseText);
+                          if (result.success) {
+                              Ext.Msg.alert('Email sent',
+                                  'A password reset link has been sent to the registered email address.');
+                          } else {
+                              Ext.Msg.alert('Error', result.error || 'Could not send reset email.');
+                          }
+                      },
+                      failure: function(response) {
+                          var result = Ext.util.JSON.decode(response.responseText);
+                          Ext.Msg.alert('Error', result.error || 'Could not send reset email.');
+                      },
+                  });
+              },
+            },
         ],
     });
     

--- a/root/static/js/grids/user_view.js
+++ b/root/static/js/grids/user_view.js
@@ -43,55 +43,87 @@ Ext.onReady(function(){
     });
 
     /* User form */
+    var formItems = [
+
+        { name:           'username',
+          fieldLabel:     'Username',
+          xtype:          'textfield',
+          readOnly:       true, },
+        
+        { name:           'name',
+          fieldLabel:     'Real name',
+          xtype:          'textfield',
+          allowBlank:     true, },
+        
+        { name:           'email',
+          fieldLabel:     'Email',
+          xtype:          'textfield',
+          vtype:          'email',
+          allowBlank:     false, },
+
+        { name:           'roles',
+          fieldLabel:     'Roles',
+          store:          role_store,
+          triggerAction:  'all',
+          mode:           'local',
+          lazyRender:     true,
+          valueField:     'role_id',
+          displayField:   'rolename',
+          emptyText:      'Select roles...',
+          hideOnSelect:   false,
+          queryMode:      'local',
+          multiSelect:    true,
+          xtype:          'lovcombo',
+          allowBlank:     true, },
+
+        { name:           'user_id',
+          value:          user_id,
+          xtype:          'hidden', },
+
+    ];
+
+    if (user_is_admin) {
+        formItems.splice(formItems.length - 1, 0, {
+            name:       'password',
+            fieldLabel: 'New password',
+            xtype:      'textfield',
+            inputType:  'password',
+            allowBlank: true,
+        });
+    }
+
     var userForm = new MyFormPanel({
 
         url:         url_user_modify,
         title:       'User details',
-            
-        items: [
-            
-            { name:           'username',
-              fieldLabel:     'Username',
-              xtype:          'textfield',
-              readOnly:       true, },
-            
-            { name:           'name',
-              fieldLabel:     'Real name',
-              xtype:          'textfield',
-              allowBlank:     true, },
-            
-            { name:           'email',
-              fieldLabel:     'Email',
-              xtype:          'textfield',
-              vtype:          'email',
-              allowBlank:     false, },
 
-            { name:           'roles',
-              fieldLabel:     'Roles',
-              store:          role_store,
-              triggerAction:  'all',
-              mode:           'local',
-              lazyRender:     true,
-              valueField:     'role_id',
-              displayField:   'rolename',
-              emptyText:      'Select roles...',
-              hideOnSelect:   false,
-              queryMode:      'local',
-              multiSelect:    true,
-              xtype:          'lovcombo',
-              allowBlank:     true, },
-
-            { name:           'user_id',
-              value:          user_id,
-              xtype:          'hidden', },
-            
-        ],
+        items: formItems,
 
         comboStores: [ role_store ],
         loadUrl:     url_user_load_form,
         idParams:    { user_id: user_id },
         waitMsg:     'Loading User details...',
     });
+
+    // After saving as admin, the server never echoes back the password
+    // hash, so the field would stay dirty and trigger the unsaved-changes
+    // warning.  Clear and reset it immediately on success.
+    if (user_is_admin) {
+        userForm.afterSave = function() {
+            var pw = userForm.getForm().findField('password');
+            if (pw) {
+                pw.setValue('');
+                pw.originalValue = '';
+            }
+            Ext.Msg.alert('Success', 'Record saved to database', function() {
+                userForm.getForm().load({
+                    url:     userForm.loadUrl,
+                    params:  userForm.idParams,
+                    waitMsg: userForm.waitMsg,
+                });
+            });
+        };
+    }
 
     var tabpanel = new Ext.TabPanel({
         activeTab: 0,

--- a/tool_dashboard/README.md
+++ b/tool_dashboard/README.md
@@ -1,5 +1,6 @@
-= Cambridge Beer Festival =
-== BeerfestDB Tool Dashboard ==
+# Cambridge Beer Festival
+
+## BeerfestDB Tool Dashboard
 
 A collection of handy little utilities for using data in beerfestdb
 
@@ -7,7 +8,7 @@ Requirements for python scripts are in requirements.txt. Put this file in /path/
 
 Also create a /path/to/.streamlit/ directory. This will hold the secrets.toml file (DO NOT commit a secrets file to github or any other version control).
 
-== Setup ==
+## Setup
 
 Create and activate a python virtual environment. Run the following to install dependencies:
 
@@ -52,7 +53,7 @@ streamlit run CBF_tool_page.py
 
 You should now be able to point your browser at the app using the URL(s) that streamlit gives you.
 
-== Docker ==
+## Docker
 
 To create a docker image, run:
 


### PR DESCRIPTION
This PR redesigns the handling of user accounts in the web interface. It adds the ability of individual users to edit their own account (name and email) and to request the server send them an email directing them to a new password reset page. Links expire after 15 mins. Admin users can either trigger these password reset emails for other users, or change passwords directly in the UI. Admin areas of the website are now hidden from non-admin users.