### PR TITLE
Add CSRF, current_festival features supporting the mobile app

### DIFF
--- a/API.md
+++ b/API.md
@@ -68,6 +68,45 @@ changes=[1,2,3]
 { "success": true, "data": { "field1": "value", ... } }
 ```
 
+### CSRF Protection
+
+All state-mutating requests (POST) are protected by a CSRF token checked
+automatically by the server (`Catalyst::Plugin::CSRFToken` with
+`auto_check` enabled).
+
+**Token lifetime:** 3600 seconds (1 hour).
+
+**Obtaining the token:**
+
+- Every response — including those to unauthenticated GET requests such as
+  the login page — includes the current token in the `X-CSRF-Token`
+  response header.
+- HTML pages also embed the token as a JavaScript variable:
+  ```js
+  var csrf_token = '<token>';
+  ```
+
+**Sending the token:**
+
+Include the token as a form body parameter named `csrf_token` in every
+POST request:
+
+```
+csrf_token=<token>&changes=[...]
+```
+
+If the token is missing, stale, or invalid the server returns HTTP **403**.
+
+**Non-browser clients** should:
+1. Make a GET request to any endpoint (e.g. `GET /login`) and read the
+   `X-CSRF-Token` response header.
+2. Include that value as `csrf_token` in the body of all subsequent POST
+   requests.
+3. Refresh the token (repeat step 1) if a 403 is received due to token
+   expiry.
+
+---
+
 ### Authentication
 
 Two authentication mechanisms are supported:
@@ -173,6 +212,14 @@ Returns all festivals.
 #### `GET /festival/load_form?festival_id=N`
 
 Returns a single festival record.
+
+**Response:** `{success, data:{...}}`
+
+---
+
+#### `GET /festival/current_festival`
+
+Returns the record for the current festival.
 
 **Response:** `{success, data:{...}}`
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,13 @@ configuration.
 To set up the additional tools dashboard, please see the 
 [dashboard README file](tool_dashboard/README.md) for instructions.
 
+Mobile App
+----------
+
+The [BeerFestMobile](https://github.com/tfrayner/beerfest-mobile) app
+will allow a cellar team to edit cask data (dips, vented/tapped/ready,
+notes etc.) directly in the database as they work on their stillages.
+This can save significant admin time between sessions.
 
 Credits
 -------

--- a/lib/BeerFestDB/Web/Controller/Festival.pm
+++ b/lib/BeerFestDB/Web/Controller/Festival.pm
@@ -76,6 +76,32 @@ sub load_form : Local {
     $self->form_json_and_detach( $c, $rs, 'festival_id' );
 }
 
+=head2 current_festival
+
+Returns the contents of load_form for the current festival. Usable by external 
+clients to retrieve the current festival details without needing to know the festival_id.
+
+=cut
+
+sub current_festival : Local {
+
+    my ( $self, $c ) = @_;
+
+    my $festival_name = $c->config->{'current_festival'}
+        or die("No current festival name set in config.");
+
+    my $obj = $c->model('DB::Festival')->find({ name => $festival_name })
+        or die("Unable to find current festival with name '$festival_name'; check config settings.");
+    
+    $c->stash->{ 'data' } = $self->generate_object_viewhash( $obj, $c );
+    $c->stash->{ 'success' } = JSON->true();
+
+    $c->forward( 'View::JSON' );
+
+    return;
+    
+}
+
 =head2 list
 
 =cut

--- a/lib/BeerFestDB/Web/Controller/Root.pm
+++ b/lib/BeerFestDB/Web/Controller/Root.pm
@@ -265,6 +265,7 @@ sub end : ActionClass('RenderView') {
         'X-XSS-Protection'          => "1; 'mode=block'",
         'Referrer-Policy'           => "strict-origin-when-cross-origin",
         'Permissions-Policy'        => "geolocation=(), microphone=(), camera=()",
+        'X-CSRF-Token'              => $c->csrf_token, # Expose CSRF token in header for JavaScript clients
     );
 }
 


### PR DESCRIPTION
Fixes supporting the BeerFestMobile app (easier to access CSRF token; new /festival/current_festival endpoint)