### PR TITLE
Fix for #146: save cask details in absence of dip data

### DIFF
--- a/lib/BeerFestDB/Web/Controller.pm
+++ b/lib/BeerFestDB/Web/Controller.pm
@@ -27,7 +27,7 @@ use List::Util qw(first);
 use Carp;
 use utf8;
 use Encode;
-use JSON::MaybeXS;
+use JSON::MaybeXS qw(JSON is_bool);
 use Data::Dumper;
 
 BEGIN {extends 'Catalyst::Controller'; }
@@ -71,7 +71,7 @@ sub generate_json_and_detach : Private {
         push @objects, $self->generate_object_viewhash($obj, $c);
     }
 
-    $c->stash->{ 'success' } = JSON->true();
+    $c->stash->{ 'success' } = JSON()->true();
     $c->stash->{ 'objects' } = \@objects;
     $c->forward( 'View::JSON' );
 }
@@ -114,15 +114,15 @@ sub form_json_and_detach : Private {
 
         if ( $obj ) {
             $c->stash->{ 'data' } = $self->generate_object_viewhash( $obj, $c );
-            $c->stash->{ 'success' } = JSON->true();
+            $c->stash->{ 'success' } = JSON()->true();
         }
         else {
-            $c->stash->{ 'success' } = JSON->false();
+            $c->stash->{ 'success' } = JSON()->false();
             $c->stash->{ 'error' } = qq{Error: Unable to find $pk "$id".};
         }
     }
     else {
-        $c->stash->{ 'success' } = JSON->false();
+        $c->stash->{ 'success' } = JSON()->false();
         $c->stash->{ 'error' } = "Error: $pk is not defined.";
     }
 
@@ -297,16 +297,16 @@ sub _add_object_column_attributes : Private {
 
             # For some reason these don't want to autoconvert, so we
             # do this manually.
-            if ( UNIVERSAL::isa($dbval, 'JSON::PP::Boolean') ) {
+            if ( is_bool($dbval) ) {
                 $dbval = $dbval ? 1 : 0;
             }
 
-	    # Don't try and save empty strings as integers - strict
-	    # MySQL mode complains.
-	    my $dt = $dbobj->result_source()
-		           ->column_info( $lookup )
-			   ->{data_type};
-	    if ( defined $dbval && $dbval eq q{} ) {
+            # Don't try and save empty strings as integers - strict
+	        # MySQL mode complains.
+	        my $dt = $dbobj->result_source()
+		                   ->column_info( $lookup )
+                           ->{data_type};
+	        if ( defined $dbval && $dbval eq q{} ) {
                 if ( $dt eq 'tinyint' ) {
                     $dbval = 0;
                 }
@@ -529,7 +529,7 @@ sub write_to_resultset : Private {
         $self->detach_with_txn_failure( $c );
     };
 
-    $c->stash->{ 'success' } = JSON->true();
+    $c->stash->{ 'success' } = JSON()->true();
     $c->forward( 'View::JSON' );
 
     return;
@@ -581,7 +581,7 @@ sub delete_from_resultset : Private {
         $self->detach_with_txn_failure( $c );
     };
 
-    $c->stash->{ 'success' } = JSON->false();
+    $c->stash->{ 'success' } = JSON()->false();
     $c->forward( 'View::JSON' );
 }
 
@@ -600,7 +600,7 @@ sub detach_with_txn_failure : Private {
     $c->response->status('403');  # Forbidden; must use this or
                                   # similar for ExtJS to detect
                                   # failure.
-    $c->stash->{ 'success' } = JSON->false();
+    $c->stash->{ 'success' } = JSON()->false();
     $c->stash->{ 'error' }   = $error;
     $c->forward( 'View::JSON' );
 }

--- a/lib/BeerFestDB/Web/Controller/Cask.pm
+++ b/lib/BeerFestDB/Web/Controller/Cask.pm
@@ -23,7 +23,7 @@ package BeerFestDB::Web::Controller::Cask;
 use Moose;
 use namespace::autoclean;
 
-use JSON::MaybeXS;
+use JSON::MaybeXS qw(JSON);
 use Data::Dumper;
 
 BEGIN {extends 'BeerFestDB::Web::PriceController'; }
@@ -304,7 +304,7 @@ sub list_dips : Local {
     }
 
     $c->stash->{ 'objects' } = $dips;
-    $c->stash->{ 'success' } = JSON->true();
+    $c->stash->{ 'success' } = JSON()->true();
 
     $c->forward( 'View::JSON' );
 }

--- a/lib/BeerFestDB/Web/Controller/CaskMeasurement.pm
+++ b/lib/BeerFestDB/Web/Controller/CaskMeasurement.pm
@@ -23,7 +23,7 @@ package BeerFestDB::Web::Controller::CaskMeasurement;
 use Moose;
 use namespace::autoclean;
 
-use JSON::MaybeXS qw/is_bool/;
+use JSON::MaybeXS qw(JSON is_bool);
 
 BEGIN {extends 'BeerFestDB::Web::Controller'; }
 
@@ -182,7 +182,7 @@ sub list : Local {
         push @casks, \%cask_info;
     }
 
-    $c->stash->{ 'success' } = JSON->true();
+    $c->stash->{ 'success' } = JSON()->true();
     $c->stash->{ 'objects' } = \@casks;
     $c->forward( 'View::JSON' );
 }
@@ -232,7 +232,7 @@ sub submit : Local {
         $self->detach_with_txn_failure( $c, $@ );
     }
     
-    $c->stash->{success} = JSON->true();
+    $c->stash->{success} = JSON()->true();
 
     $c->forward( 'View::JSON' );
 }

--- a/lib/BeerFestDB/Web/Controller/CaskMeasurement.pm
+++ b/lib/BeerFestDB/Web/Controller/CaskMeasurement.pm
@@ -23,7 +23,7 @@ package BeerFestDB::Web::Controller::CaskMeasurement;
 use Moose;
 use namespace::autoclean;
 
-use JSON::MaybeXS;
+use JSON::MaybeXS qw/is_bool/;
 
 BEGIN {extends 'BeerFestDB::Web::Controller'; }
 
@@ -249,39 +249,46 @@ sub _save_records : Private {
         }
 
         # Cask-level editing at the point of dip entry for convenience.
-        foreach my $field ( qw(cask_comment) ) {
+        foreach my $field ( qw(cask_comment internal_reference cellar_reference) ) {
 
             my ( $cfield ) = ( $field =~ m/\A cask_(.*)/xms );
 
             # Empty string is allowed.
-            $cask->set_column($cfield, delete $rec->{$field}) if defined $rec->{$field};
+            if ( defined $rec->{$field} ) {
+                $c->log->debug("Setting $cfield to '$rec->{$field}' for cask_id=$rec->{cask_id}");
+                $cask->set_column($cfield, delete $rec->{$field});
+            }
         }
         foreach my $field ( qw(is_vented is_tapped is_ready is_condemned) ) {
 
-            # No empty strings allowed for tinyints.
-            $cask->set_column($field, delete $rec->{$field})
-                if ( defined $rec->{$field} && $rec->{$field} ne q{} );
+            # Boolean fields need confirming as defined and not q{} since the UI may pass in false values.
+            if ( defined $rec->{$field} && is_bool($rec->{$field}) ) {
+                $c->log->debug("Setting $field to '$rec->{$field}' for cask_id=$rec->{cask_id}");
+                $cask->set_column($field, delete $rec->{$field});
+            }
         }
         $cask->update();
 
         # We are assuming all measurement units are the same as the
         # cask size unit (i.e. gallons, for the most part).
 
-	# Allow the UI to pass in an empty string to indicate we
-	# should delete the pre-existing dip.
-	if ( defined ( $rec->{volume} ) && $rec->{volume} eq q{} ) {
-	    my %attr  = map { $_ => $rec->{$_} } qw( cask_id measurement_batch_id );
-	    if ( my $dbobj = $rs->find(\%attr) ) {
-		$dbobj->delete();
-	    }
-	}
-	else {
-	    $rec->{container_measure_id}
-	        = $cask->cask_management_id()
+	    # Allow the UI to pass in an empty string to indicate we
+	    # should delete the pre-existing dip.
+	    if ( defined ( $rec->{volume} ) && $rec->{volume} eq q{} ) {
+            $c->log->debug("Deleting cask measurement for cask_id=$rec->{cask_id}, batch_id=$rec->{measurement_batch_id}");
+	        my %attr  = map { $_ => $rec->{$_} } qw( cask_id measurement_batch_id );
+	        if ( my $dbobj = $rs->find(\%attr) ) {
+		        $dbobj->delete();
+	        }
+    	}
+	    elsif ( defined $rec->{volume} || defined $rec->{comment} ) {
+            $c->log->debug("Saving cask measurement for cask_id=$rec->{cask_id}, batch_id=$rec->{measurement_batch_id}");
+	        $rec->{container_measure_id}
+	            = $cask->cask_management_id()
                        ->container_size_id()
-		       ->get_column('container_measure_id');
-	    $self->build_database_object( $rec, $c, $rs );
-	}
+		               ->get_column('container_measure_id');
+	        $self->build_database_object( $rec, $c, $rs );
+	    }
     }
 
     return;

--- a/lib/BeerFestDB/Web/Controller/Festival.pm
+++ b/lib/BeerFestDB/Web/Controller/Festival.pm
@@ -22,7 +22,7 @@
 package BeerFestDB::Web::Controller::Festival;
 use Moose;
 use namespace::autoclean;
-use JSON::MaybeXS;
+use JSON::MaybeXS qw(JSON);
 
 BEGIN {extends 'BeerFestDB::Web::Controller'; }
 
@@ -156,7 +156,7 @@ sub status : Local {
 
     unless ( $festival ) {
         $c->stash->{ 'error' }   = "Error: Festival not found.";
-        $c->stash->{ 'success' } = JSON->false();
+        $c->stash->{ 'success' } = JSON()->false();
         $c->forward( 'View::JSON' );
     }
 
@@ -171,13 +171,13 @@ sub status : Local {
     my $beercat = $c->model('DB::ProductCategory')->find({ description => 'beer' });
     unless ( $beercat ) {
         $c->stash->{ 'error' }   = "Error: beer ProductCategory not found.";
-        $c->stash->{ 'success' } = JSON->false();
+        $c->stash->{ 'success' } = JSON()->false();
         $c->forward( 'View::JSON' );
     }
     my $kilsize = $c->model('DB::ContainerSize')->find({ description => 'kilderkin' });
     unless ( $kilsize ) {
         $c->stash->{ 'error' }    = "Error: kilderkin ContainerSize not found.";
-        $c->stash->{ 'success' }  = JSON->false();
+        $c->stash->{ 'success' }  = JSON()->false();
         $c->forward( 'View::JSON' );
     }
 
@@ -289,7 +289,7 @@ sub status : Local {
     );
 
     $c->stash->{ 'data' }    = \%obj_hash;
-    $c->stash->{ 'success' } = JSON->true();
+    $c->stash->{ 'success' } = JSON()->true();
 
     $c->forward( 'View::JSON' );
 }

--- a/lib/BeerFestDB/Web/Controller/FestivalProduct.pm
+++ b/lib/BeerFestDB/Web/Controller/FestivalProduct.pm
@@ -26,7 +26,7 @@ use namespace::autoclean;
 use List::Util qw( min first );
 use Digest::SHA qw( sha1_hex );
 use Carp;
-use JSON::MaybeXS;
+use JSON::MaybeXS qw(JSON);
 
 BEGIN {extends 'BeerFestDB::Web::PriceController'; }
 
@@ -274,11 +274,11 @@ sub list_status : Local {
 
     if ( my $rc = $@ ) {
         $rc =~ s/\n \z//xms;
-        $c->stash->{success} = JSON->false();
+        $c->stash->{success} = JSON()->false();
         $c->stash->{error}   = $rc;
     }
     else {
-        $c->stash->{success} = JSON->true();
+        $c->stash->{success} = JSON()->true();
         $c->stash->{objects} = $objects;
     }
 
@@ -338,8 +338,8 @@ sub _build_allergen_data : Private {
         if ( defined $pa->present ) {
             $allergen_data{ $pa->product_allergen_type_id->description() }
                 = $pa->present
-                ? JSON->true()
-                : JSON->false();
+                ? JSON()->true()
+                : JSON()->false();
         }
     }
 
@@ -366,7 +366,7 @@ sub _build_product_data : Private {
         abv          => $product->nominal_abv(),
         style        => $style ? $style->description() : undef,
         description  => $product->description(),
-	long_description => $product->long_description(),
+        long_description => $product->long_description(),
         allergens    => $self->_build_allergen_data( $product, $c ),
         is_vegan     => $product->is_vegan(),
     };

--- a/lib/BeerFestDB/Web/Controller/ProductOrder.pm
+++ b/lib/BeerFestDB/Web/Controller/ProductOrder.pm
@@ -22,7 +22,7 @@
 package BeerFestDB::Web::Controller::ProductOrder;
 use Moose;
 use namespace::autoclean;
-use JSON::MaybeXS;
+use JSON::MaybeXS qw(JSON);
 
 BEGIN {extends 'BeerFestDB::Web::PriceController'};
 
@@ -148,7 +148,7 @@ sub submit : Local {
         $self->detach_with_txn_failure( $c, $@ );
     }
 
-    $c->stash->{ 'success' } = JSON->true();
+    $c->stash->{ 'success' } = JSON()->true();
     $c->forward( 'View::JSON' );
 }
 

--- a/lib/BeerFestDB/Web/Controller/Root.pm
+++ b/lib/BeerFestDB/Web/Controller/Root.pm
@@ -22,7 +22,7 @@
 package BeerFestDB::Web::Controller::Root;
 use Moose;
 use namespace::autoclean;
-use JSON::MaybeXS;
+use JSON::MaybeXS qw(JSON);
 
 use Data::Dumper;
 
@@ -130,7 +130,7 @@ sub login : Global {
 
     }
 
-    my $j = JSON->new;
+    my $j = JSON()->new;
     my $json_req = $c->request->param( 'data' );
 
     $c->res->status('403');
@@ -148,7 +148,7 @@ sub login : Global {
 
         # ExtJS form redirects to url_success_target URI.
 	    $c->res->status('200');
-        $c->stash->{ 'success' } = JSON->true();
+        $c->stash->{ 'success' } = JSON()->true();
         $c->forward( 'View::JSON' );
     }
     else {
@@ -157,7 +157,7 @@ sub login : Global {
 
         $c->res->status('401');
         $c->stash->{ 'message' } = 'Login failed.';
-        $c->stash->{ 'success' } = JSON->false();
+        $c->stash->{ 'success' } = JSON()->false();
         $c->forward( 'View::JSON' );
     }
 
@@ -178,7 +178,7 @@ sub logout : Global {
     $c->logout;
 
     $c->flash->{ 'message' } = 'Successfully logged out.';
-    $c->stash->{ 'success' } = JSON->true();
+    $c->stash->{ 'success' } = JSON()->true();
     $c->res->redirect( $c->uri_for('/') );
 }
 
@@ -196,7 +196,7 @@ sub json_logout : Global {
     $c->logout;
     
     $c->flash->{ 'message' } = 'Successfully logged out.';
-    $c->stash->{ 'success' } = JSON->true();
+    $c->stash->{ 'success' } = JSON()->true();
     $c->detach( $c->view( 'JSON' ) );
 }
 

--- a/root/static/js/grids/cask_measurement.js
+++ b/root/static/js/grids/cask_measurement.js
@@ -87,7 +87,7 @@ Ext.onReady(function(){
           editor:     new Ext.form.Checkbox({
           })},
         { id:         'internal_reference',
-          header:     'Cellar No.',
+          header:     'Cellaring Order',
           dataIndex:  'internal_reference',
           width:      50,
           editor:     new Ext.form.NumberField({
@@ -95,7 +95,7 @@ Ext.onReady(function(){
               readOnly: true,
           })},
         { id:         'cellar_reference',
-          header:     'Festival ID',
+          header:     'Cask ID',
           dataIndex:  'cellar_reference',
           width:      50,
           editor:     new Ext.form.NumberField({


### PR DESCRIPTION
The /caskmeasurement/grid action is all kinds of special-cased; this PR reviews and fixes its logic so that cask info can still be saved even if there's no dip volume given.