### PR TITLE
Fixing example (docker) config error

### DIFF
--- a/beerfestdb_web_site.yml
+++ b/beerfestdb_web_site.yml
@@ -115,9 +115,9 @@ Plugin::OpenIDConnect:
     code_ttl: 600
 
 Plugin::CSRFToken:
-  max_age: 3600, # Token lifespan in seconds
-  auto_check: 1,
-  default_secret: 'a very long and secret string that should be overridden in production',
+  max_age: 3600  # Token lifespan in seconds
+  auto_check: 1
+  default_secret: 'a very long and secret string that should be overridden in production'
 
 # Email configuration for password reset messages.
 email:


### PR DESCRIPTION
Broken example config YAML that then misconfigures the default settings in the docker image. This fixes.