### PR TITLE
Tweaks for v1.2: relax k8s pod/service quota; update docs

### DIFF
--- a/deployment/k8s/beerfestdb-volumes.yaml
+++ b/deployment/k8s/beerfestdb-volumes.yaml
@@ -14,9 +14,9 @@ spec:
   hard:
     cpu: '2'
     memory: '8Gi'
-    pods: '5'
+    pods: '6'
     resourcequotas: '1'
-    services: '5'
+    services: '6'
 ---
 apiVersion: v1
 kind: PersistentVolume

--- a/lib/BeerFestDB/Loader.pm
+++ b/lib/BeerFestDB/Loader.pm
@@ -878,8 +878,8 @@ sub _coerce_headings {
         qr/cask [_ -]* cellar [_ -]* id/ixms           => $CASK_CELLAR_ID,
         qr/cask [_ -]* festival [_ -]* id/ixms         => $CASK_FESTIVAL_ID,
         qr/cask [_ -]* count/ixms                      => $CASK_COUNT,
-        qr/cask [_ -]* size/ixms                       => $CASK_SIZE,
-        qr/cask [_ -]* unit/ixms                       => $CASK_UNIT,
+        qr/cask [_ -]* size/ixms                       => $CASK_SIZE,   # Specifically for container_size.description, _not_ volume.
+#        qr/cask [_ -]* unit/ixms                       => $CASK_UNIT,  # TODO could be reinstated but only if cask_volume and dispense_method are also available. Use web UI otherwise.
         qr/cask [_ -]* price/ixms                      => $CASK_PRICE,
         qr/cask [_ -]* comment/ixms                    => $CASK_COMMENT,
         qr/cask [_ -]* graveyard (?:[_ -]* location)?/ixms  => $CASK_GRAVEYARD_LOCATION,

--- a/lib/BeerFestDB/Loader.pm
+++ b/lib/BeerFestDB/Loader.pm
@@ -452,9 +452,6 @@ sub _load_data {
             'ContainerSize')
         : undef;
 
-    # Assumes default currency
-    my $order_price = $self->parse_price( $datahash->{$ORDER_PRICE} );
-
     my $count = $datahash->{$CASK_COUNT};
     unless ( defined $count && $count ne q{} ) {
         $count = 0;
@@ -473,6 +470,18 @@ sub _load_data {
     my $contact;
 
     if ( my $batchname = $datahash->{$ORDER_BATCH_NAME} ) { # ProductOrder
+        
+        # Assumes default currency
+        my $order_price;
+        if ( $self->value_is_acceptable( $datahash->{$ORDER_PRICE} ) ) {
+            if ( $self->value_is_acceptable( $datahash->{$CASK_PRICE} ) ) {
+                die("Simultaneous use of order_price and cask_price is not supported.");
+            }
+            $order_price = $self->parse_price( $datahash->{$ORDER_PRICE} );
+        } elsif ( $self->value_is_acceptable( $datahash->{$CASK_PRICE} ) ) {
+            $order_price = $self->parse_price( $datahash->{$CASK_PRICE} ) * $count;
+        }
+
         my $order_batch = $self->_load_column_value(
             {
                 festival_id            => $festival,

--- a/lib/BeerFestDB/Role/CsvParser.pm
+++ b/lib/BeerFestDB/Role/CsvParser.pm
@@ -98,7 +98,7 @@ sub getline {
     confess "CSV parser not initialized" unless $csv_parser;
     confess "Filehandle not initialized" unless $self->filehandle;
 
-    print ".";  # progress indicator
+    print STDERR ".";  # progress indicator
 
     my $fields;
     GETLINE:
@@ -145,7 +145,7 @@ sub confirm_eof {
                 $self->csv_parser()->error_input()));
     }
 
-    print "\nEnd of file reached successfully.\n";
+    warn("\nEnd of file reached successfully.\n");
 
     return (1);
 }
@@ -166,9 +166,7 @@ sub get_headers {
     my @header;
     HEADER:
     while ( scalar @header == 0 ) {
-        print "Reading header line...$self\n";
         my $line = $self->getline(1);
-        print "Read header line...\n";
         last HEADER unless defined $line;
         my $lstr = join('', @$line);
         next HEADER if $lstr =~ /^\s*#/;  # skip comments (N.B. redundant with getline, but added for extra safety)

--- a/lib/BeerFestDB/Role/CsvParser.pm
+++ b/lib/BeerFestDB/Role/CsvParser.pm
@@ -98,7 +98,7 @@ sub getline {
     confess "CSV parser not initialized" unless $csv_parser;
     confess "Filehandle not initialized" unless $self->filehandle;
 
-    print "Reading line from CSV file...\n";
+    print ".";  # progress indicator
 
     my $fields;
     GETLINE:
@@ -144,6 +144,8 @@ sub confirm_eof {
                 $mess,
                 $self->csv_parser()->error_input()));
     }
+
+    print "\nEnd of file reached successfully.\n";
 
     return (1);
 }

--- a/lib/BeerFestDB/Role/CsvParser.pm
+++ b/lib/BeerFestDB/Role/CsvParser.pm
@@ -98,8 +98,6 @@ sub getline {
     confess "CSV parser not initialized" unless $csv_parser;
     confess "Filehandle not initialized" unless $self->filehandle;
 
-    print STDERR ".";  # progress indicator
-
     my $fields;
     GETLINE:
     while (1) {

--- a/lib/BeerFestDB/Web/Controller/Cask.pm
+++ b/lib/BeerFestDB/Web/Controller/Cask.pm
@@ -203,6 +203,13 @@ sub list : Local {
                        ->search_related('casks',
                                         { 'product_id.product_category_id' => $category_id },
                                         {
+                                            prefetch => [
+                                                'cask_management_id',
+                                                { gyle_id => [
+                                                    { festival_product_id => 'product_id' },
+                                                    'company_id',
+                                                ] },
+                                            ],
                                             join     => {
                                                 gyle_id => {
                                                     festival_product_id => {

--- a/lib/BeerFestDB/Web/Controller/Cask.pm
+++ b/lib/BeerFestDB/Web/Controller/Cask.pm
@@ -260,7 +260,17 @@ sub list_by_stillage : Local {
 
     my $rs = $c->model( 'DB::Cask' )
         ->search({ 'cask_management_id.stillage_location_id' => $id },
-                 { join => 'cask_management_id' });
+                 {
+                    prefetch => [
+                        'cask_management_id',
+                        { gyle_id => [
+                            { festival_product_id => 'product_id' },
+                              'company_id',
+                          ]
+                        },
+                    ],
+                    join => 'cask_management_id',
+                 });
 
     $self->generate_json_and_detach( $c, $rs );
 }
@@ -280,8 +290,17 @@ sub list_by_festival_product : Local {
                ->search({
                    'cask_management_id.festival_id' => $fp->get_column('festival_id'),
                    'gyle_id.festival_product_id' => $fp->get_column('festival_product_id'),
-               }, { join => [ { gyle_id => 'festival_product_id' },
-                              { cask_management_id => 'festival_id' } ] });
+                }, {
+                prefetch => [
+                    'cask_management_id',
+                    { gyle_id => [
+                        { festival_product_id => 'product_id' },
+                        'company_id',
+                        ] },
+                ],
+                join => [ { gyle_id => 'festival_product_id' },
+                          { cask_management_id => 'festival_id' } ]
+                });
 
     $self->generate_json_and_detach( $c, $rs );
 }

--- a/lib/BeerFestDB/Web/Controller/CaskMeasurement.pm
+++ b/lib/BeerFestDB/Web/Controller/CaskMeasurement.pm
@@ -102,7 +102,7 @@ sub list : Local {
     my ( $self, $c, $batch_id, $stillage_id ) = @_;
 
     # This listing actually revolves around casks rather than
-    # cask_measurements. Perhaps it's in the wrong controller? FIXME?
+    # cask_measurements.
     unless ( defined $stillage_id && defined $batch_id ) {
         die("Error: stillage_location_id or measurement_batch_id not defined.");
     }
@@ -114,7 +114,19 @@ sub list : Local {
         $c->res->redirect( $c->uri_for('/default') );
         $c->detach();
     }
-    my $rs = $stillage->search_related('cask_managements')->search_related('casks');
+    my $rs = $stillage->search_related('cask_managements')
+                      ->search_related('casks', undef,
+                      {
+                          prefetch => [
+                              'cask_management_id',
+                              { gyle_id => [
+                                  { festival_product_id => 'product_id' },
+                                  'company_id',
+                                ]
+                              },
+                              'cask_measurements',
+                          ],
+                      });
 
     my $batch = $c->model( 'DB::MeasurementBatch' )
                   ->find({measurement_batch_id => $batch_id});
@@ -200,7 +212,7 @@ sub list_by_cask : Local {
         $rs = $c->model( 'DB::CaskMeasurement' )->search_rs( { cask_id => $cask_id } );
     }
     else {
-        $rs = $c->model( 'DB::CaskMeasurement' );  # FIXME is this actually needed?
+        die("Error: cask_id not defined.");
     }
 
     $self->generate_json_and_detach( $c, $rs );

--- a/lib/BeerFestDB/Web/Controller/FestivalProduct.pm
+++ b/lib/BeerFestDB/Web/Controller/FestivalProduct.pm
@@ -125,7 +125,10 @@ sub list : Local {
             { 'product_id.product_category_id' => $category_id },
             {
                 join     => { product_id => 'product_category_id' },
-                prefetch => { product_id => 'product_category_id' },
+                prefetch => [
+                    { product_id => [ 'company_id' ] },
+                    'festival_id',
+                ],
             });
     }
     else {
@@ -144,7 +147,10 @@ sub list_by_product : Local {
 
     my $rs;
     if ( defined $product_id ) {
-        $rs = $c->model( 'DB::FestivalProduct' )->search_rs( { product_id => $product_id } );
+        $rs = $c->model( 'DB::FestivalProduct' )->search_rs(
+            { product_id => $product_id },
+            { prefetch => [ 'festival_id' ] },
+        );
     }
     else {
         $c->stash->{error} = qq{Product ID not supplied.};
@@ -167,7 +173,10 @@ sub list_by_company : Local {
     if ( defined $company_id ) {
         $rs = $c->model( 'DB::FestivalProduct' )
             ->search_rs( { 'product_id.company_id' => $company_id },
-                         { join => 'product_id' } );
+                         {
+                            join => 'product_id',
+                            prefetch => [ 'festival_id' ],
+                         } );
     }
     else {
         $c->stash->{error} = qq{Company ID not supplied.};
@@ -435,14 +444,11 @@ sub _derive_status_report : Private {
                 'product_orders',
                 { %$cond, is_final => 1 },
                 { join => $attr->{join},
-		  # Prefetch should only pull out *required*
-		  # relationships. Optional relationships behave
-		  # unexpectedly.
                   prefetch => {
-		      %{ $attr->{join} },
-		      container_size_id => 'dispense_method_id',
-		      product_id        => 'company_id',
-		  },
+                      %{ $attr->{join} },
+                      container_size_id => 'dispense_method_id',
+                      product_id        => 'company_id',
+                  },
               },
             );
 
@@ -485,9 +491,6 @@ sub _derive_status_report_by_dispense_method : Private {
                         casks => {
                             cask_management_id => {
                                 container_size_id => 'dispense_method_id' }}}};
-    # Prefetch should only pull out *required*
-    # relationships. Optional relationships behave
-    # unexpectedly.
     my $prefetch = { %{ $attr->{join} },
                         gyles => {
                             casks => {
@@ -496,7 +499,7 @@ sub _derive_status_report_by_dispense_method : Private {
                         },
                         product_id => [
                             'company_id',
-    			    'product_category_id',
+                            'product_category_id',
                         ]};
     my $condition = { %$cond, 'container_size_id.dispense_method_id' => $dispense->id };
 

--- a/lib/BeerFestDB/Web/Controller/Gyle.pm
+++ b/lib/BeerFestDB/Web/Controller/Gyle.pm
@@ -49,14 +49,14 @@ sub BUILD {
         comment           => 'comment',
         ext_reference     => 'external_reference',
         int_reference     => 'internal_reference',
-       festival_name     => {
-           festival_product_id => {
-               festival_id => 'name',
-           },
-       },
-       company_name      => {
-           company_id => 'name',
-       },
+        festival_name     => {
+            festival_product_id => {
+                festival_id => 'name',
+            },
+        },
+        company_name      => {
+            company_id => 'name',
+        },
     });
 }
 
@@ -78,7 +78,12 @@ sub list_by_festival_product : Local {
 
     my ( $self, $c, $id ) = @_;
 
-    my $rs = $c->model( 'DB::Gyle' )->search({ festival_product_id => $id });
+    my $rs = $c->model( 'DB::Gyle' )->search(
+        { festival_product_id => $id },
+        {
+            prefetch => [ 'company_id' ],
+        },
+    );
 
     $self->generate_json_and_detach( $c, $rs );
 }
@@ -93,7 +98,10 @@ sub list_by_festival : Local {
 
     my $rs = $c->model( 'DB::Gyle' )->search(
         { 'festival_product_id.festival_id' => $id },
-        { join => 'festival_product_id' },
+        {
+            join => 'festival_product_id',
+            prefetch => [ 'company_id', { festival_product_id => 'festival_id' } ],
+        },
     );
 
     $self->generate_json_and_detach( $c, $rs );

--- a/lib/BeerFestDB/Web/Controller/Product.pm
+++ b/lib/BeerFestDB/Web/Controller/Product.pm
@@ -138,7 +138,10 @@ sub list : Local {
     # split this method, e.g. building on the FestivalProduct class instead.
 
     my ( $rs, $festival );
-    my $cond = defined $category_id ? { product_category_id => $category_id } : {};
+    my $cond = defined $category_id ? { product_category_id => $category_id }
+                                    : {};
+    my $prefetch = defined $category_id ? [ 'company_id' ]
+                                        : [ 'company_id', 'product_category_id' ];
     if ( defined $festival_id ) {
         $festival = $c->model( 'DB::Festival' )->find({festival_id => $festival_id});
         unless ( $festival ) {
@@ -147,10 +150,10 @@ sub list : Local {
             $c->detach();
         }
         $rs = $festival->search_related('festival_products')
-                       ->search_related('product_id', $cond);
+                       ->search_related('product_id', $cond, { prefetch => $prefetch });
     }
     else {
-        $rs = $c->model( 'DB::Product' )->search_rs($cond);
+        $rs = $c->model( 'DB::Product' )->search_rs($cond, { prefetch => $prefetch });
     }
     
     $self->generate_json_and_detach( $c, $rs );
@@ -173,9 +176,10 @@ sub list_by_company : Local {
     if ( defined $company_id ) {
         my %query = ( company_id => $company_id );
         if ( defined $category_id ) {
-            $query{ product_category_id } = $category_id;
+            $query{ 'me.product_category_id' } = $category_id;
         }
-        $rs = $c->model( 'DB::Product' )->search_rs( \%query );
+        $rs = $c->model( 'DB::Product' )->search_rs( \%query,
+            { prefetch => [ 'product_category_id' ] });
     }
     else {
         $c->stash->{error} = 'Company ID not provided.';
@@ -198,9 +202,13 @@ sub list_by_festival : Local {
     if ( defined $festival_id ) {
         my %query = ( 'festival_products.festival_id' => $festival_id );
         if ( defined $category_id ) {
-            $query{ product_category_id } = $category_id;
+            $query{ 'me.product_category_id' } = $category_id;
         }
-        $rs = $c->model( 'DB::Product' )->search_rs( \%query, { join => 'festival_products' } );
+        $rs = $c->model( 'DB::Product' )->search_rs( \%query,
+            {
+                join => 'festival_products',
+                prefetch => [ 'company_id', 'product_category_id' ],
+            } );
     }
     else {
         $c->stash->{error} = 'Festival ID not provided.';
@@ -236,7 +244,13 @@ sub list_by_order_batch : Local {
         $rs = $batch->search_related('product_orders')
                     ->search_related('product_id',
                                      defined $category_id
-                                         ? { product_category_id => $category_id } : {});
+                                         ? { product_category_id => $category_id } : {},
+                                     {
+                                        prefetch => defined $category_id
+                                            ? [ 'company_id' ]
+                                            : [ 'company_id', 'product_category_id' ],
+                                     }
+    );
     }
     else {
         $c->stash->{error} = 'OrderBatch ID not provided.';

--- a/lib/BeerFestDB/Web/Controller/ProductOrder.pm
+++ b/lib/BeerFestDB/Web/Controller/ProductOrder.pm
@@ -103,10 +103,13 @@ sub list : Local {
     # action in Product, it can in principle support a listing of all
     # orders ever.
 
-    my ( $cond, $attrs );
+    my $cond;
+    my $attrs = { prefetch => [ 'product_id',
+                                { product_id => 'company_id' },
+                                'order_batch_id' ] };
     if ( defined $category_id ) {
         $cond  = { 'product_id.product_category_id' => $category_id };
-        $attrs = { join => { product_id => 'product_category_id' } };
+        $attrs->{join} = { product_id => 'product_category_id' };
     }
 
     my ( $rs, $order_batch );

--- a/tool_dashboard/README.md
+++ b/tool_dashboard/README.md
@@ -10,7 +10,12 @@ Also create a /path/to/.streamlit/ directory. This will hold the secrets.toml fi
 
 ## Setup
 
-Create and activate a python virtual environment. Run the following to install dependencies:
+Install system package prerequisites. For example, on a Debian Linux box, you will need the following packages:
+- python.\[version\]-venv
+- mariadb-client
+- libmariadb-dev
+
+Check out BeerFestDB from Github. Run the following in the tool_dashboard directory. This will create and activate a python virtual environment, and install dependencies:
 
 ``` bash
 python -m venv .venv

--- a/usage_cheatsheet
+++ b/usage_cheatsheet
@@ -154,8 +154,7 @@ When beer comes
 	NOTE: new casks added at this point should NOT have an order batch assigned
 	if there are fewer casks than expected, mark all as "arrived", then go to Products Received to delete one (or more, as needed)
   Prices go in Products Received tab, sale price column
-	in web interface, enter prices in pence
-	BUT load_data.pl takes pounds
+	Both the web interface and load_data.pl take prices in pounds
   
 For dip sheets:
   Manually enter "Measurement batches" -- otherwise no dip data slots print out!
@@ -392,22 +391,7 @@ This doesn't filter by product category, but for casks it doesn't need to - only
 
 Appendix 9 - Online tool dashboard introduced 2026
 
-To run the tools dashboard locally:
-
-- Check out beerfestdb from github
-	make sure .gitignore includes the '.streamlit' line
-
-- Set up python virtual environment as directed
-- Install required modules via pip install
-- It will also need underlying modules
-	e.g. a Linux setup will need python.[version]-venv, mariadb-client, libmariadb-dev
-
-When setup is complete:
-- Log in to pin via the 'sock' command (this does the required port forwarding)Q
-	% ssh -L 3307:/run/mysqld/mysqld.sock pin.cambridge-camra.org.uk
-
-- While logged in to pin, run the streamlit script (on a local command line):
-% streamlit run CBF_tool_page.py
+Navigate to https://beerfestdbtools.cambridgebeerfestival.uk/. Log in using your BeerFestDB user account.
 
 Tips on using the Sale Price Generator:
 - Timing: Recommend using it after preload_festival_casks.pl has been run
@@ -423,3 +407,14 @@ Tips on using the Sale Price Generator:
 Also remember that the database doesn't really support same product, different dispense (e.g. beer in cask & keg) at same festival. (The schema dates back to before that was a thing; only International had any keg back then.) We have always kludged by manually editing one of the cask end signs in the .tex file after running dump_to_template.pl!
 
 
+
+_Developer notes:_ 
+  The simplest way to use the dashboard is to use the production version described above. If you plan 
+  to run the dashboard locally on your own computer (e.g. when testing new features), follow these steps: 
+  - Set up your virtual environment and install dependencies as described in tool_dashboard/README.md
+  - Create a secrets.toml file as described (leave mysql host and port unchanged)
+  - Log in to pin, forwarding its mysqld socket to port 3306 on your computer:
+	  % ssh -L 3306:/run/mysqld/mysqld.sock pin.cambridge-camra.org.uk
+  - Run the streamlit app:
+    % streamlit run CBF_tool_page.py
+  - Aim your browser at http://127.0.0.1:8051/ to access the dashboard

--- a/usage_cheatsheet
+++ b/usage_cheatsheet
@@ -2,6 +2,15 @@ Various notes that have proven handy for actually using BeerfestDB for the Cambr
 
 Author: Midori Harris, Head Cellar Manager
 
+Platform and resources
+
+The festival cellar maintains two websites that are used to manage our festival-wide process:
+
+- https://beerfestdb.cambridgebeerfestival.uk/ - the main stock control database.
+- https://beerfestdbtools.cambridgebeerfestival.uk/ - a dashboard-like interface providing useful functions which we'll describe below.
+
+In addition, there are many scripts which need to be run on our 'pin' server which we'll also describe.
+
 General data entry
 
 To get special characters in, go to http://unicode-table.com/, find
@@ -43,7 +52,7 @@ Info gathering spreadsheet --> load_data input
 	d. Delete extra column(s) from ALL rows
 6. Correct columns headers as needed (see list below)
 7. Add remaining required columns: festival name & year, product category, order batch, is-final ('1' for yes). Example header row:
-    brewery_name	product_name	product_abv	product_style	cask_size	cask_count	order_sor	distributor_name	order_batch	product_category	festival_name	festival_year	order_finalized
+    brewery_name	product_name	product_abv	product_style	cask_size	cask_count	cask_price	order_sor	distributor_name	order_batch	product_category	festival_name	festival_year	order_finalized
     	a. For cask_size, use one of the text descriptions from the database (see list below). Watch for typos, especially if a load fails. (New 2017-04; previously used number of gallons)
 	b. Need order_finalized to tick the 'ordered' boxes ... and make orders actually get spawned! product_category and festival_year are less critical; although the category is useful, the load won't actually fail without it. (Based on experience in 2019.)
 8. Feed to load_data.pl with default beerfestdb_web.yml (i.e. default protected categories including company, product)
@@ -62,33 +71,48 @@ To get the current list of container size descriptions from beerfestdb, use quer
 +----------------------+
 | description          |
 +----------------------+
+| pin                  |
+| firkin               |
 | 10 gallon            |
-| 10L polypin          |
 | 11 gallon            |
-| 12 x 750 mL case     |
-| 20L keg              |
-| 20L KeyKeg           |
-| 20L polypin          |
+| kilderkin            |
 | 22 gallon            |
+| barrel               |
+| hogshead             |
+| 6 gallon KeyKeg/cask |
+| 10 L KeyKeg          |
+| 20 L KeyKeg          |
+| 30 L KeyKeg          |
+| 4.37gal cider tub    |
+| 5 gallon             |
+| 20 L bag-in-box      |
 | 25 cL bottle         |
-| 30L keg              |
-| 30L KeyKeg           |
 | 33 cL bottle         |
 | 35.5 cl bottle       |
 | 37.5 cL bottle       |
-| 4.37gal cider tub    |
-| 5 gallon             |
+| 44 cL bottle         |
+| 47.3 cL bottle       |
 | 50 cL bottle         |
-| 50L keg              |
-| 6 gallon KeyKeg/cask |
-| 6 x 750 mL case      |
 | 70 cL bottle         |
 | 75 cL bottle         |
-| barrel               |
-| firkin               |
-| kilderkin            |
-| pin                  |
+| 6 x 750 mL case      |
+| 12 x 750 mL case     |
+| 5 L polypin          |
+| 10 L polypin         |
+| 20 L polypin         |
+| 25 L polypin         |
+| 10 L keg             |
+| 12 L keg             |
+| 20 L keg             |
+| 30 L keg             |
+| 50 L keg             |
+| 33 cL can            |
+| 37.5 cL can          |
+| 44 cL can            |
+| 50 cL can            |
 +----------------------+
+
+If needed, new container sizes can be created by an admin-level user in the web interface.
 
 To load mead or wine data using load_data.pl
   punt and
@@ -97,17 +121,13 @@ To load mead or wine data using load_data.pl
   OR really punt and just
     a. load up everything as though there's just one of each product/size combo
     b. Optional (and only worth doing if db used for stock control): update quantities in web interface upon arrival, or later (if later, add new lines in web interface or use load_data.pl -- if scripted, don't forget to subtract 1 from each qty)
-  (tried this:
-    one. include a cask_unit column, set to 'litre'
-    two. put number of L in cask_size column; hope no floating point problems bite us
-   but got cranky error messages, e.g. "DBIx::Class::ResultSet::find_or_create(): DBI Exception: DBD::mysql::st execute failed: Incorrect decimal value: '50 cL bottle' for column 'container_volume' at row 1 [for Statement "INSERT INTO container_size ( container_measure_id, container_volume) VALUES ( ?, ? )" with ParamValues: 0='2', 1='50 cL bottle'] at /home/tfrayner/beerfestdb/lib/BeerFestDB/Loader.pm line 661")
 
 Cider, perry, apple juice
   - Ciderdom may or may not provide container sizes and quantities. If they don't, there are two options:
         a. include order_batch column, and dummy values for cask_size and cask_quantity (e.g. size 5 gallon, qty 1); OR
         b. omit order_batch, cask_size and cask_quantity, and unprotect FestivalProduct in beerfestdb.yml
   - Handle cider & perry ABVs at gyle level (and load correspondingly, and annoyingly, late in proceedings)
-        use load-data.pl once to get companies and product names in and connected to the festival, then prepare a second file for gyle ABVs.
+        use load_data.pl once to get companies and product names in and connected to the festival, then prepare a second file for gyle ABVs.
         - for the first round, include these columns: brewery_name, product_name, product_style, cask_size, cask_count, distributor_name, order_sor, order_batch, product_category, festival_name, festival_year, order_finalized (it shouldn't require product_abv, but if it does, include a blank column)
         - in the second round, include: gyle_ABV, brewery_name, product_name, product_category, product_sale_price, festival_name, festival_year
 
@@ -118,14 +138,7 @@ Foreign beer
 
 To get new info to replace old (e.g. improved tasting notes), use load_data.pl overwrite mode (-o option).
 
-To spawn summer fest programme beer list fodder:
-  1. go into mysql command line (% mysql -p beerfestdb)
-  2. the query is
-	select * from programme_notes_view where festival='[name of festival of interest]'
-	e.g. select * from programme_notes_view where festival='41st Cambridge Beer festival' 
-  3. invoke from unix comand line to funnel output to a file
-	echo 'select * from programme_notes_view where festival="[name of festival of interest]"' | mysql -p beerfestdb > [output_file.txt]
-	e.g. % echo 'select * from programme_notes_view where festival="41st Cambridge Beer Festival"' | mysql -p beerfestdb > cbf41_beerlist.txt
+To spawn summer fest programme beer list fodder, log in to the dashboard web interface and select 'Programme Beer List' from the sidebar menu. From there you can download the list in CSV or TSV format. If for any reason the dashboard isn't working, see appendix 10 for how to generate the list directly from the database.
 
 For cask lists (delivery & stillage plan checklists; cask labels)
   1. Run preload_festival_casks.pl to bring cask entries into existence
@@ -133,7 +146,6 @@ For cask lists (delivery & stillage plan checklists; cask labels)
   2. Use dump_to_template.pl with options:
      a. delivery checklist: -t templates/delivery_checklist.tt2 -o distributor
         optional: manually edit .tex to split by day (because of course not quite everything arrives on the specified Wednesday)
-
      b. cask list for stillage plan: dump_to_template.pl -t ~tfrayner/beerfestdb/util/templates/stillage_planning.tt2 -o cask_management --filters "cask_size_name=30L KeyKeg,cask_size_name=20L KeyKeg,brewery=Adnams,brewery=Grain,brewery=Bexar County,brewery=Three Blind Mice,brewery=Woodforde's" > filtered_cask_list.tex
 	- the above assumes a separate KeyKeg bar
 	- include a brewery=[name] key/value pair for each brewery bar (example is from CBF44 in 2017)
@@ -157,14 +169,14 @@ When beer comes
 	Both the web interface and load_data.pl take prices in pounds
   
 For dip sheets:
-  Manually enter "Measurement batches" -- otherwise no dip data slots print out!
+  Manually enter "Measurement batches" -- otherwise no dip data slots print out! For best results, include short day-of-week as the measurement batch description (e.g. Mo, Tu, We, Th, Fr, Sa).
   Assign each cask to a bar
         interface: All casks received - Stillage column
 	OR
 	use update_cask_details.pl -a -i $file (cask ID & location ID in $file)
 	  headers cask_festival_id, stillage_location (use name for stillage location, e.g. DMZ)
 	  need the -a flag to get it to "move a cask", i.e. change its location assignment, even from nothing to something
-	  handy way to get cask IDs: take relevant columns from index card data see below)
+	  (handy way to get cask IDs: take relevant columns from index card data see below)
 
 For cask end signs, can have festival logo in upper right corner (use
 the -l [logo] option) or leave the space for something else, such as a
@@ -204,7 +216,7 @@ Report Graphs
     % SWEAVE_STYLEPATH_DEFAULT=TRUE R CMD Sweave dip_figure_analysis.Rnw
   Generates output file dip_figure_analysis.tex and a bunch of .pdf files (for the figures) if all has gone well
   If it spits out an error message about "negative per diem dips found", it means there's a case where a cask magically has more beer at a later dip than it did at an earlier dip. Correct the dip data rather than the laws of physics.
-   easiest way is to regenerate the dip sheets (see above) and eyeball them
+   easiest way is to regenerate the dip sheets (see above) and eyeball them - the error message should list the cask IDs affected
    copy dip_figure_analysis.Rnw into local directory in one's ~ if necessary for write-access reasons
 
 October & Winter festivals
@@ -267,8 +279,7 @@ column headings for files to load (using load_data.pl):
         cask_festival_id
         cask_count
         cask_size
-        cask_unit
-        cask_price
+        cask_price  for price per cask; see also order_price below
         cask_comment
         cask_measurement_date
         cask_measurement_volume
@@ -280,7 +291,7 @@ column headings for files to load (using load_data.pl):
         order_received
         order_comment
         order_sor	order_sale_or_return also works
-        order_price  for _total_ order price, i.e. cask_price x cask_count
+        order_price  for total order price, i.e. cask_price x cask_count
         contact_type
         contact_first_name
         contact_last_name
@@ -407,8 +418,6 @@ Tips on using the Sale Price Generator:
 
 Also remember that the database doesn't really support same product, different dispense (e.g. beer in cask & keg) at same festival. (The schema dates back to before that was a thing; only International had any keg back then.) We have always kludged by manually editing one of the cask end signs in the .tex file after running dump_to_template.pl!
 
-
-
 _Developer notes:_ 
   The simplest way to use the dashboard is to use the production version described above. If you plan 
   to run the dashboard locally on your own computer (e.g. when testing new features), follow these steps: 
@@ -419,3 +428,17 @@ _Developer notes:_
   - Run the streamlit app:
     % streamlit run CBF_tool_page.py
   - Aim your browser at http://127.0.0.1:8051/ to access the dashboard
+
+
+
+Appendix 10 - Generate Festival Programme Beer List file
+
+If the dashboard isn't working:
+
+  1. go into mysql command line (% mysql -p beerfestdb)
+  2. the query is
+	select * from programme_notes_view where festival='[name of festival of interest]'
+	e.g. select * from programme_notes_view where festival='41st Cambridge Beer festival' 
+  3. invoke from unix comand line to funnel output to a file
+	echo 'select * from programme_notes_view where festival="[name of festival of interest]"' | mysql -p beerfestdb > [output_file.txt]
+	e.g. % echo 'select * from programme_notes_view where festival="41st Cambridge Beer Festival"' | mysql -p beerfestdb > cbf41_beerlist.txt

--- a/usage_cheatsheet
+++ b/usage_cheatsheet
@@ -280,6 +280,7 @@ column headings for files to load (using load_data.pl):
         order_received
         order_comment
         order_sor	order_sale_or_return also works
+        order_price  for _total_ order price, i.e. cask_price x cask_count
         contact_type
         contact_first_name
         contact_last_name


### PR DESCRIPTION
- Minor tweak to quotas so the pods can be torn down and redeployed without spamming the syslog.
- Update usage_cheatsheet to include some changes from v1.1
- Add `prefetch` statements to the large database queries to speed them up substantially.