### PR TITLE
170 autogenerate webui cask

### DIFF
--- a/lib/BeerFestDB/Web/Controller/Cask.pm
+++ b/lib/BeerFestDB/Web/Controller/Cask.pm
@@ -362,6 +362,16 @@ sub build_database_object : Private {
         my ($caskman, $caskman_rec, $caskman_mvmap);
         ( $rec, $caskman_rec, $caskman_mvmap ) = $self->_extract_caskman_terms( $rec, $mv_map );
 
+        # If $caskman_rec->{'cellar_reference'} is null, query the database for the next 
+        # available cellar_reference for the festival and assign it to the record.
+        if ( ! defined $caskman_rec->{'cellar_reference'} ) {
+            $c->log->debug("No cellar_reference found in record, querying database for next available value.");
+            $caskman_rec->{'cellar_reference'} =
+                $c->model( 'DB::CaskManagement' )
+                  ->search({ 'festival_id' => $caskman_rec->{'festival_id'} } )
+                  ->get_column('cellar_reference')->max() + 1;
+        }
+
         $c->log->debug("Cask management model-view map: " . Dumper $caskman_mvmap);
         $c->log->debug("Cask management record data: " . Dumper $caskman_rec);
         $c->log->debug("Cleaned Cask record data: " . Dumper $rec);

--- a/root/static/css/extras.css
+++ b/root/static/css/extras.css
@@ -45,3 +45,10 @@ textarea.bfd-required {
 td.bfd-required-cell .x-grid3-cell-inner {
     background-color: #ffeef2;
 }
+
+/* ── Read-only grid toolbar buttons ────────────────────────────────────────
+   When a MyEditorGrid is created with readOnly: true its toolbar buttons are
+   disabled.  Reduce the icon opacity so they look visually greyed-out. */
+.x-toolbar .x-item-disabled button {
+    opacity: 0.8;
+}

--- a/root/static/js/classes.js
+++ b/root/static/js/classes.js
@@ -497,6 +497,7 @@ MyNumberRenderer = function() {
 
 MyFormPanel = Ext.extend(Ext.form.FormPanel, {
 
+    readOnly:    false,
     labelAlign:  'right',
     labelWidth:  150,
     frame:       true,
@@ -517,6 +518,7 @@ MyFormPanel = Ext.extend(Ext.form.FormPanel, {
                 text:    'Save Changes',
                 tooltip: 'Write changes to the database',
                 iconCls: 'icon-save-table',
+                disabled: !!this.readOnly,
                 handler: function(b, e) {
                     var panel = this;
                     var doSave = function() {
@@ -557,6 +559,7 @@ MyFormPanel = Ext.extend(Ext.form.FormPanel, {
                 handler: function(b, e) {
                     this.getForm().reset();
                 },
+                disabled: !!this.readOnly,
                 scope: this,
             }],
             initialConfig: {

--- a/root/static/js/classes.js
+++ b/root/static/js/classes.js
@@ -245,6 +245,7 @@ RemoveButton = Ext.extend(Ext.Button, {
 
 MyEditorGrid = Ext.extend(Ext.grid.EditorGridPanel, {
 
+    changesOnly:        false,
     columnLines:        true,
     stripeRows:         true,
     trackMouseOver:     true,
@@ -267,6 +268,7 @@ MyEditorGrid = Ext.extend(Ext.grid.EditorGridPanel, {
                 // On selection change, set enabled state of the removeButton
                 // which was placed into the GridPanel using the ref config
                 selectionchange: function(sm) {
+                    if (this.changesOnly) { return; }
                     if (sm.getCount()) {
                         this.removeButton.enable();
                     } else {
@@ -320,19 +322,28 @@ MyEditorGrid = Ext.extend(Ext.grid.EditorGridPanel, {
             plugins:            action,
             tbar:
             [
-                new NewButton({text:   'New ' + this.objLabel,
-                               grid:   this}),
+                // Some grids don't support addition/deletion of rows, so we don't always
+                // activate those buttons in the toolbar.
+                new NewButton({text:     'New ' + this.objLabel,
+                               grid:    this,
+                               disabled: !!this.changesOnly,
+                }),
                 new SaveButton({
                     grid:          this,
                     recordChanges: this.recordChanges,
+//                    disabled:      !!this.changesOnly,
                 }),
-                new DiscardButton({grid:this}),
+                new DiscardButton({grid:     this,
+//                                   disabled: !!this.changesOnly,
+                }),
                 new RemoveButton({text:         'Remove ' + this.objLabel + 's',
                                   grid:         this,
                                   sm:           sm,
                                   ref:          '../removeButton',
                                   idField:      this.idField,
-                                  deleteUrl:    this.deleteUrl}),
+                                  deleteUrl:    this.deleteUrl,
+                                  disabled:     true,
+                }),
             ],
             listeners: {
                 beforerender: function(myGrid) {

--- a/root/static/js/grids/cask_measurement.js
+++ b/root/static/js/grids/cask_measurement.js
@@ -155,6 +155,7 @@ Ext.onReady(function(){
 
     var myGrid = new MyEditorGrid(
         {
+            changesOnly:        true,
             objLabel:           'Dip',
             idField:            'cask_measurement_id',
             autoExpandColumn:   'volume',

--- a/root/static/js/grids/festival_cask.js
+++ b/root/static/js/grids/festival_cask.js
@@ -175,6 +175,7 @@ Ext.onReady(function(){
 
     var myGrid = new MyEditorGrid(
         {
+            changesOnly:        true,
             objLabel:           'Cask',
             idField:            'cask_id',
             autoExpandColumn:   'product_id',

--- a/root/static/js/grids/festival_product_view.js
+++ b/root/static/js/grids/festival_product_view.js
@@ -328,7 +328,7 @@ Ext.onReady(function(){
                   dataIndex: 'festival_ref',
                   width:      50,
                   editor:     new Ext.form.TextField({
-                      allowBlank: false,
+                      allowBlank: true,
                   })},
                 { id:        'int_reference',
                   header:    'Cellar Cask ID',

--- a/root/static/js/grids/festival_view.js
+++ b/root/static/js/grids/festival_view.js
@@ -259,10 +259,11 @@ Ext.onReady(function(){
         waitMsg:     'Loading Festival details...',
     });
 
-    var festivalStatus = new MyFormPanel({ // FIXME not entirely appropriate for readOnly.
+    var festivalStatus = new MyFormPanel({
 
         title:       'Festival status',
-            
+        readOnly:    true,
+
         items: [
             { name:       'kils_ordered',
               fieldLabel: 'Total kils of beer ordered',

--- a/root/static/js/grids/product_view.js
+++ b/root/static/js/grids/product_view.js
@@ -375,6 +375,7 @@ Ext.onReady(function(){
     /* Festival Product grid */
     var fpGrid = new MyEditorGrid(
         {
+            changesOnly:        true,
             objLabel:           'Festival Product',
             idField:            'festival_product_id',
             autoExpandColumn:   'festival_id',

--- a/root/static/js/grids/stillage_cask.js
+++ b/root/static/js/grids/stillage_cask.js
@@ -189,6 +189,7 @@ Ext.onReady(function(){
         layout: 'fit',
         items: new MyEditorGrid(
             {
+                changesOnly:        true,
                 objLabel:           'Cask',
                 idField:            'cask_id',
                 autoExpandColumn:   'name',

--- a/usage_cheatsheet
+++ b/usage_cheatsheet
@@ -148,10 +148,11 @@ When beer comes
 	can edit size of existing casks
 	to add cask, need existing gyle for the beer
 	  to add a gyle, type "auto-generated" as its ID, and select the brewery from the pulldown in the "actual brewer" column
-	manually assign cask ID, preferably next available in sequence
-	  use this query:  select max(cm.cellar_reference) from cask_management cm, festival f where f.festival_id=cm.festival_id and f.name='41st Cambridge Beer Festival';
-	  for "new cask", mandatory columns are Festival cask ID, Cask size, Gyle, and Distributor
-	NOTE: new casks added at this point should NOT have an order batch assigned
+  leave the cask ID blank to auto-assign the next available ID in sequence
+    alternatively, manually assign cask ID;
+  	  use this query:  select max(cm.cellar_reference) from cask_management cm, festival f where f.festival_id=cm.festival_id and f.name='41st Cambridge Beer Festival';
+	    for "new cask", mandatory columns are Cask size, Gyle, and Distributor
+	NOTE: new casks added at this point should NOT have an order batch assigned (the web page will not let you)
 	if there are fewer casks than expected, mark all as "arrived", then go to Products Received to delete one (or more, as needed)
   Prices go in Products Received tab, sale price column
 	in web interface, enter prices in pence


### PR DESCRIPTION
Autogenerates cask ID when creating new casks with in the festival product view pages. 

Cosmetic changes:
- Properly greys out the "Add..." and "Remove..." buttons in the longer festival-wide and stillage-wide cask listings, where addition and removal have never been supported.
- Similar treatment for the "Submit changes" and "Discard changes" buttons in the top-level status view, which has always been read-only.

Closes #170