### PR TITLE
Reinstate /cask/list; fix R reporting unicode errors

### DIFF
--- a/R/BeerFestDB/R/Festival.R
+++ b/R/BeerFestDB/R/Festival.R
@@ -121,7 +121,7 @@ Festival <- R6::R6Class(
         ungroup() %>%
         mutate(volume_lost = ifelse(is_condemned == 1, cask_volume, volume_lost)) %>%
         mutate(volume_sold = cask_volume - volume_lost) %>%
-        mutate(abv_class = cut(abv, breaks = private$abv_breaks))
+        mutate(abv_class = cut(as.numeric(abv), breaks = private$abv_breaks))
 
       # Clean up the abv_class factor levels to remove parentheses and replace commas with " - "
       levels(data$abv_class) <- gsub('\\(|\\]', '', gsub(',',' - ',levels(data$abv_class)))

--- a/R/BeerFestDB/R/getFestivalData.R
+++ b/R/BeerFestDB/R/getFestivalData.R
@@ -249,6 +249,10 @@ getFestivalData <- function(baseuri, festname, prodcat, auth = NULL, .opts = lis
   cp <- merge(cp, dipmat, by.x = "cask_id", by.y = 0, all.x = TRUE) %>%
     mutate(cask_volume = as.numeric(cask_volume))
 
+  if (nrow(cp) == 0) {
+    warning("No cask data found for festival '", festname, "' and product category '", prodcat, "'.")
+  }
+
   return(Festival$new(cp, ...))
 }
 

--- a/R/BeerFestDB/R/queryBFDB.R
+++ b/R/BeerFestDB/R/queryBFDB.R
@@ -64,7 +64,7 @@ getBFData <- function(dbclass, action, params = c(), columns = NULL,
       if (is.null(el) || (length(el) == 1L && is.na(el))) {
         NA_character_
       } else {
-        as.character(el)[[1L]]
+        .normalize_utf8_scalar(as.character(el)[[1L]])
       }
     }, character(1L))
   })
@@ -100,6 +100,110 @@ getBFData <- function(dbclass, action, params = c(), columns = NULL,
   }
 
   return(res)
+}
+
+# These functions are defensive coding against bad UTF-8 data in the JSON API response.
+#  The API should always return valid UTF-8, but some installations have in practice 
+#  yielded badly encoded sequences (possibly from older mysql versions?)
+.looks_like_utf8_mojibake <- function(text) {
+  text <- enc2utf8(text)
+
+  # Invalid UTF-8 can occur in damaged payloads; treat as not-mojibake here
+  # and let upstream JSON parsing handle hard failures.
+  if (is.na(iconv(text, from = "UTF-8", to = "UTF-8", sub = NA))) {
+    return(FALSE)
+  }
+
+  # Common marker sequences seen when UTF-8 bytes are mis-decoded as Latin-1/CP1252.
+  # We intentionally avoid broad single-letter classes (e.g. Ø, â) because they
+  # occur legitimately in names such as "To Øl" and "Cwrw Iâl".
+  has_mojibake_markers <- grepl("(?:Ã.|Â.|â€|â€™|â€œ|â€˜|â€\x9d|â€“|â€”|â€¦|â„¢|â€¢)",
+                                text, perl = TRUE, useBytes = TRUE)
+  if (!has_mojibake_markers) {
+    return(FALSE)
+  }
+
+  codepoints <- utf8ToInt(text)
+  if (any(codepoints > 255L)) {
+    return(FALSE)
+  }
+
+  repaired <- tryCatch({
+    x <- rawToChar(as.raw(codepoints))
+    Encoding(x) <- "UTF-8"
+    if (is.na(iconv(x, from = "UTF-8", to = "UTF-8", sub = NA))) {
+      return(NA_character_)
+    }
+    enc2utf8(x)
+  }, error = function(e) {
+    NA_character_
+  })
+
+  if (is.na(repaired) || identical(repaired, text)) {
+    return(FALSE)
+  }
+
+  if (is.na(iconv(repaired, from = "UTF-8", to = "UTF-8", sub = NA))) {
+    return(FALSE)
+  }
+
+  if (grepl("\uFFFD", repaired, fixed = TRUE, useBytes = TRUE)) {
+    return(FALSE)
+  }
+
+  marker_score <- function(x) {
+    m <- gregexpr("(?:Ã.|Â.|â€|â€™|â€œ|â€˜|â€\x9d|â€“|â€”|â€¦|â„¢|â€¢)", x, perl = TRUE, useBytes = TRUE)[[1L]]
+    if (identical(m[1L], -1L)) 0L else length(m)
+  }
+
+  marker_score(repaired) < marker_score(text)
+}
+
+.normalize_utf8_scalar <- function(text) {
+  if (is.na(text)) {
+    return(text)
+  }
+
+  text <- enc2utf8(text)
+  if (!.looks_like_utf8_mojibake(text)) {
+    return(text)
+  }
+
+  codepoints <- utf8ToInt(text)
+  repaired <- rawToChar(as.raw(codepoints))
+  Encoding(repaired) <- "UTF-8"
+  if (is.na(iconv(repaired, from = "UTF-8", to = "UTF-8", sub = NA))) {
+    return(text)
+  }
+  repaired <- enc2utf8(repaired)
+
+  if (.looks_like_utf8_mojibake(repaired)) {
+    return(text)
+  }
+
+  repaired
+}
+
+.normalize_utf8_value <- function(value) {
+  if (is.list(value)) {
+    return(lapply(value, .normalize_utf8_value))
+  }
+
+  if (is.character(value)) {
+    return(vapply(value, .normalize_utf8_scalar, character(1L), USE.NAMES = FALSE))
+  }
+
+  value
+}
+
+.sanitize_json_payload <- function(payload) {
+  payload <- enc2utf8(payload)
+  iconv(payload, from = "UTF-8", to = "UTF-8", sub = "byte")
+}
+
+.parse_bfdb_json <- function(payload) {
+  payload <- .sanitize_json_payload(payload)
+  .normalize_utf8_value(rjson::fromJSON(payload))
 }
 
 ###############################################################################
@@ -181,7 +285,7 @@ setMethod(
     )
 
     ## Check the response for errors.
-    rc <- try(status <- rjson::fromJSON(status$value()))
+    rc <- try(status <- .parse_bfdb_json(status$value()))
 
     if (inherits(rc, "try-error")) {
       stop(sprintf("Error encountered: %s", rc))
@@ -308,7 +412,7 @@ setMethod(
   )
 
   ## Check the response for errors.
-  status <- rjson::fromJSON(status$value())
+  status <- .parse_bfdb_json(status$value())
   if (!isTRUE(status$success)) {
     stop(status$message)
   }
@@ -356,7 +460,7 @@ setMethod(
 
   ## Check the response for errors. FIXME test this part once the
   ## json_logout method has been properly installed on the server.
-  status <- rjson::fromJSON(status$value())
+  status <- .parse_bfdb_json(status$value())
   if (!isTRUE(status$success)) {
     stop(status$message)
   }

--- a/R/BeerFestDB/tests/testthat/test-getBFData.R
+++ b/R/BeerFestDB/tests/testthat/test-getBFData.R
@@ -42,6 +42,87 @@ test_that("getBFData fills missing fields with NA", {
   expect_true(is.na(result[result$name == "Beer B", "brewery"]))
 })
 
+test_that("getBFData repairs mojibake in UTF-8 text fields", {
+  mock_objects <- list(
+    list(name = "Imperial CrÃ¨me BearlÃ©e", beer_id = "1")
+  )
+
+  local_mocked_bindings(
+    queryBFDB = function(...) mock_objects,
+    .package = "BeerFestDB"
+  )
+
+  result <- getBFData("Cask", "list", auth = list())
+
+  expect_equal(result$name, "Imperial Crème Bearlée")
+})
+
+test_that("getBFData repairs additional mojibake patterns", {
+  mock_objects <- list(
+    list(name = "FranÃ§ois", beer_id = "2")
+  )
+
+  local_mocked_bindings(
+    queryBFDB = function(...) mock_objects,
+    .package = "BeerFestDB"
+  )
+
+  result <- getBFData("Cask", "list", auth = list())
+
+  expect_equal(result$name, "François")
+})
+
+test_that("getBFData does not alter valid UTF-8 text", {
+  mock_objects <- list(
+    list(name = "Crème brûlée", beer_id = "3")
+  )
+
+  local_mocked_bindings(
+    queryBFDB = function(...) mock_objects,
+    .package = "BeerFestDB"
+  )
+
+  result <- getBFData("Cask", "list", auth = list())
+
+  expect_equal(result$name, "Crème brûlée")
+})
+
+test_that("getBFData preserves valid UTF-8 names with Ø and â without warnings", {
+  mock_objects <- list(
+    list(name = "To Øl", beer_id = "10"),
+    list(name = "Cwrw Iâl Community Brewing Company", beer_id = "11")
+  )
+
+  local_mocked_bindings(
+    queryBFDB = function(...) mock_objects,
+    .package = "BeerFestDB"
+  )
+
+  expect_warning(
+    result <- getBFData("Cask", "list", auth = list()),
+    NA
+  )
+
+  expect_equal(result$name, c("To Øl", "Cwrw Iâl Community Brewing Company"))
+})
+
+test_that(".parse_bfdb_json handles invalid UTF-8 payload bytes without warnings", {
+  payload_raw <- c(
+    charToRaw('{"success":true,"objects":[{"name":"'),
+    as.raw(c(0xC3, 0x28)),
+    charToRaw('","beer_id":"9"}]}')
+  )
+  payload <- rawToChar(payload_raw)
+  Encoding(payload) <- "UTF-8"
+
+  expect_warning(
+    parsed <- BeerFestDB:::.parse_bfdb_json(payload),
+    NA
+  )
+  expect_equal(parsed$success, TRUE)
+  expect_equal(parsed$objects[[1L]]$beer_id, "9")
+})
+
 test_that("getBFData converts *_id columns to integer", {
   mock_objects <- list(
     list(name = "Beer A", beer_id = "1"),

--- a/R/dip_figure_analysis.qmd
+++ b/R/dip_figure_analysis.qmd
@@ -27,6 +27,7 @@ params:
   prodcat: 'beer'
   username: ''
   password: ''
+  ssl_verify: true
 ---
 
 
@@ -67,9 +68,11 @@ creds <- with(params, list(username = username, password = password))
 ```
 
 ```{r data_retrieval, include=FALSE}
-f <- currentFestival(baseuri = params$baseuri, auth = creds)
+f <- with(params, currentFestival(baseuri = baseuri, auth = creds,
+                                 .opts=list(ssl.verifypeer=ssl_verify, ssl.verifyhost=ssl_verify)))
 
-festival <- with(params, getFestivalData(baseuri, f$name, prodcat, auth = creds, dipnames = days))
+festival <- with(params, getFestivalData(baseuri, f$name, prodcat, auth = creds, dipnames = days,
+                                         .opts=list(ssl.verifypeer=ssl_verify, ssl.verifyhost=ssl_verify)))
 
 festival$write_csv("full_dip_dump.csv")
 ```
@@ -159,7 +162,7 @@ drop <- rev(rev(colnames(dp))[ seq_len(dn) ])
 
 We calculate the daily sales levels for each cask, and aggregate those figures by beer style. The graphs in @fig-overall-sales show the amount of beer sold per day, broken down by style.
 
-```{r overall_sales_plot}
+```{r}
 #| fig-width: 6
 #| fig-height: 4
 #| label: fig-overall-sales
@@ -287,7 +290,7 @@ The bar chart in each case shows the ratio of predicted to observed sales, and i
 
 ## By ABV
 
-```{r sales_by_abv}
+```{r}
 #| fig-width: 6
 #| fig-height: 4
 #| label: fig-sales-by-abv
@@ -306,7 +309,7 @@ plotModelRatio( cps, 'abv_class', drop=drop )
 
 ## By Style
 
-```{r sales_by_style}
+```{r}
 #| fig-width: 6
 #| fig-height: 4
 #| label: fig-sales-by-style
@@ -325,7 +328,7 @@ plotModelRatio( cps, 'style', drop=drop )
 
 ## By Region
 
-```{r sales_by_region}
+```{r}
 #| fig-width: 6
 #| fig-height: 4
 #| label: fig-sales-by-region
@@ -344,7 +347,7 @@ plotModelRatio( cps, 'region', drop=drop )
 
 ## By Stillage Location
 
-```{r sales_by_stillage}
+```{r}
 #| fig-width: 6
 #| fig-height: 4
 #| label: fig-sales-by-stillage
@@ -367,7 +370,7 @@ plotModelRatio( cps, 'stillage', drop=drop )
 
 Here we simply show the proportion of beers ordered by geographic region, style, and ABV class, to give an idea of the diversity of beers ordered for the festival. These figures are based on the original order, omitting sale-or-return casks, and do not take into account any unsold or condemned casks.
 
-```{r order_regional_distributions}
+```{r}
 #| fig-width: 6
 #| fig-height: 6
 #| label: fig-order-distributions
@@ -412,7 +415,7 @@ As shown in @fig-order-recommendations, we can use these estimated sales rates t
 
 We restrict this analysis to **uncondemned, non-sale-or-return casks**, since we don't want to base our ordering recommendations on beer that's unsold for either of those reasons. Bear in mind that this analysis may recommend increasing the order of beers which sell out early due to one or more casks being condemned; such cases should be reviewed carefully to ensure that the recommendation is appropriate.
 
-```{r order_recommendations}
+```{r}
 #| column: page
 #| label: fig-order-recommendations
 
@@ -459,7 +462,7 @@ The following sections contain more technical information that may be of interes
 
 The plot in @fig-cask-vs-product-sale-rate shows the relationship between the cask sale rate and the product sale rate for each product. The cask sale rate is calculated based on the average time taken to sell a full cask, modelling each cask separately, while the product sale rate is calculated across casks using a single model. The latter case is more influenced by slow-selling casks for which there are more dip measurements, so the results tend to be lower than the cask sale rate. The plot shows that there is a positive correlation between the two sale rates, but that the product sale rate is generally lower than the cask sale rate. Outlier products are labelled in the plot, and may warrant closer inspection of their dip figures to examine any unexpected features of their sales pattern.
 
-```{r testing_cask_vs_product_sale_rate}
+```{r}
 #| fig-width: 6
 #| fig-height: 6
 #| label: fig-cask-vs-product-sale-rate

--- a/lib/BeerFestDB/Web/Controller/Cask.pm
+++ b/lib/BeerFestDB/Web/Controller/Cask.pm
@@ -183,6 +183,49 @@ sub load_form : Local {
     $self->form_json_and_detach( $c, $rs, 'cask_id' );
 }
 
+=head2 list
+
+Full cask listing; this computationally-expensive action is primarily used by
+the R post-festival reporting code and should not be used unless really needed.
+
+=cut
+
+sub list : Local {
+
+    my ( $self, $c, $festival_id, $category_id ) = @_;
+
+    my ( $rs, $festival );
+    if ( defined $festival_id ) {
+        $festival = $c->model( 'DB::Festival' )->find({festival_id => $festival_id});
+        unless ( $festival ) {
+            $c->stash->{error} = qq{Festival ID "$festival_id" not found.};
+            $c->res->redirect( $c->uri_for('/default') );
+            $c->detach();
+        }
+        $rs = $festival->search_related('cask_managements')
+                       ->search_related('casks',
+                                        { 'product_id.product_category_id' => $category_id },
+                                        {
+                                            prefetch => [
+                                                'cask_management_id',
+                                                { gyle_id => [
+                                                    { festival_product_id => 'product_id' },
+                                                    'company_id',
+                                                ] },
+                                            ],
+                                            join     => {
+                                                gyle_id => {
+                                                    festival_product_id => {
+                                                        product_id => 'product_category_id' } } },
+                                        });
+    }
+    else {
+        die('Error: festival_id not defined.');
+    }
+
+    $self->generate_json_and_detach( $c, $rs );
+}
+
 =head2 list_by_stillage
 
 =cut

--- a/t/controllers.t
+++ b/t/controllers.t
@@ -88,8 +88,8 @@ subtest 'BayPosition' => sub {
 # ---------------------------------------------------------------------------
 subtest 'Cask' => sub {
     $cellar->get_ok('/cask/view/1',                        'view should succeed');
-#    $cellar->get_ok('/cask/list/1/1',                      'list should succeed');
-#    $cellar->get_ok('/cask/grid/1/1',                      'grid should succeed');
+    $cellar->get_ok('/cask/list/1/1',                      'list should succeed');
+    $cellar->get_ok('/cask/grid/1/1',                      'grid should succeed');
     $cellar->get_ok('/cask/load_form',                     'load_form should succeed');
     $cellar->get_ok('/cask/list_by_stillage/1',            'list_by_stillage should succeed');
     $cellar->get_ok('/cask/list_by_festival_product/1',    'list_by_festival_product should succeed');

--- a/t/controllers.t
+++ b/t/controllers.t
@@ -89,7 +89,6 @@ subtest 'BayPosition' => sub {
 subtest 'Cask' => sub {
     $cellar->get_ok('/cask/view/1',                        'view should succeed');
     $cellar->get_ok('/cask/list/1/1',                      'list should succeed');
-    $cellar->get_ok('/cask/grid/1/1',                      'grid should succeed');
     $cellar->get_ok('/cask/load_form',                     'load_form should succeed');
     $cellar->get_ok('/cask/list_by_stillage/1',            'list_by_stillage should succeed');
     $cellar->get_ok('/cask/list_by_festival_product/1',    'list_by_festival_product should succeed');


### PR DESCRIPTION
This PR includes defensive code to check for unicode encoding errors in the values returned by the JSON API and fix them in the report. Such errors seem to be a function of the local installation (i.e., present in production but not in my dev environment; possibly related to the mysql server being used?).

We also reinstate the `/cask/list` URL path which was removed as being unneeded; it is, however, needed for the R reporting so we'll keep it for now.